### PR TITLE
Compile fixes for opengl.hpp for every version of glalt

### DIFF
--- a/opengl.hpp
+++ b/opengl.hpp
@@ -18,8 +18,6 @@
 //GL_HPP_DIRECT_STATE_ACCESS //if defined, assumes you have the DIRECT_STATE_ACCESS extension (this should be runtime, but whatever...)
 //Note, semantics of gl3.hpp are equivalent to GL_HPP_DIRECT_STATE_ACCESS
 
-//This file supports OpenGL 3.1 or higher (3.0 is not supported because of the lack of GL_COPY_READ_BUFFER)
-
 /*#ifndef GL_HPP_COMMON_HPP
 #error "This file needs to have an opengl API selected from glhpp and included before this file.  Such as #include<glhpp/gl3.1.hpp>"
 #endif*/
@@ -532,11 +530,23 @@ SHADER_STORAGE}_BARRIER_BIT
 	void Uniform(const std::string& n,const GLint& v1,const GLint& v2);
 	void Uniform(const std::string& n,const GLint& v1,const GLint& v2,const GLint& v3);
 	void Uniform(const std::string& n,const GLint& v1,const GLint& v2,const GLint& v3,const GLint& v4);
-	void Uniform(const std::string& n,const GLuint& v1);
-	void Uniform(const std::string& n,const GLuint& v1,const GLuint& v2);
-	void Uniform(const std::string& n,const GLuint& v1,const GLuint& v2,const GLuint& v3);
-	void Uniform(const std::string& n,const GLuint& v1,const GLuint& v2,const GLuint& v3,const GLuint& v4);
 	
+    #if defined(GL_ALT_FUNDEF_Uniform1ui)
+    void Uniform(const std::string& n,const GLuint& v1);
+    #endif
+    
+    #if defined(GL_ALT_FUNDEF_Uniform2ui)
+    void Uniform(const std::string& n,const GLuint& v1,const GLuint& v2);
+    #endif
+    
+    #if defined(GL_ALT_FUNDEF_Uniform3ui)
+    void Uniform(const std::string& n,const GLuint& v1,const GLuint& v2,const GLuint& v3);
+    #endif
+    
+    #if defined(GL_ALT_FUNDEF_Uniform4ui)
+    void Uniform(const std::string& n,const GLuint& v1,const GLuint& v2,const GLuint& v3,const GLuint& v4);
+    #endif
+    
 	//matrix and array uniforms
 	//should only exist in their specializations
 	template<class T,GLuint sz>
@@ -678,18 +688,35 @@ public:
 	void DisableAttrib(GLuint index);
     #endif
     
+    
     #if defined(GL_ALT_FUNDEF_VertexArrayVertexAttribOffsetEXT) || defined(GL_ALT_FUNDEF_VertexAttribPointer)
 	void AttribPointer(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const GLvoid * pointer);
+    
+    #if defined(GL_ALT_FUNDEF_GenBuffers)
     void AttribPointer(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const Buffer& b,GLsizeiptr offset);
+    #endif
+    
     void Attrib(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const GLvoid * pointer);
-	void Attrib(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const Buffer& b,GLsizeiptr offset);
+    
+    #if defined(GL_ALT_FUNDEF_GenBuffers)
+    void Attrib(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const Buffer& b,GLsizeiptr offset);
+    #endif
+
     #endif
     
     #if defined(GL_ALT_FUNDEF_VertexArrayVertexAttribIOffsetEXT) || defined(GL_ALT_FUNDEF_VertexAttribIPointer)
 	void AttribIPointer(GLuint index,GLint size,GLenum type,GLsizei stride,const GLvoid * pointer);
-	void AttribIPointer(GLuint index,GLint size,GLenum type,GLsizei stride,const Buffer& b,GLsizeiptr offset);
+	
+    #if defined(GL_ALT_FUNDEF_GenBuffers)
+    void AttribIPointer(GLuint index,GLint size,GLenum type,GLsizei stride,const Buffer& b,GLsizeiptr offset);
+    #endif
+    
 	void AttribI(GLuint index,GLint size,GLenum type,GLsizei stride,const GLvoid * pointer);
-	void AttribI(GLuint index,GLint size,GLenum type,GLsizei stride,const Buffer& b,GLsizeiptr offset);
+	
+    #if defined(GL_ALT_FUNDEF_GenBuffers)
+    void AttribI(GLuint index,GLint size,GLenum type,GLsizei stride,const Buffer& b,GLsizeiptr offset);
+    #endif
+
     #endif
     
     #if defined(GL_ALT_FUNDEF_BindVertexArray) && defined(GL_ALT_FUNDEF_BindBuffer)
@@ -831,7 +858,9 @@ public:
 	}
     #endif
 
+    #if defined(GL_ALT_FUNDEF_BindMultiTextureEXT) && defined(GL_ALT_FUNDEF_ActiveTexture)
     void BindMulti(GLuint unit, GLenum targ = 0);
+    #endif
 
     #if defined(GL_ALT_FUNDEF_TexImage1D) || defined(GL_ALT_FUNDEF_TextureImage1DEXT)
     void Image1D(GLenum targ,GLint level,GLint internalformat, GLsizei width, GLint border, GLenum format, GLenum type, const GLvoid *data)
@@ -860,16 +889,25 @@ public:
 	}
     #endif
     
-    #if defined(GL_ALT_FUNDEF_TexImage3D) || defined(GL_ALT_FUNDEF_TextureImage3DEXT)
+    #if defined(GL_ALT_FUNDEF_TexImage3D) || defined(GL_ALT_FUNDEF_TextureImage3DEXT) || defined(GL_ALT_FUNDEF_TexImage3DEXT)
+    
+    #if defined(GL_ALT_FUNDEF_TexImage3D)
+    #define TexImage3DFunc glTexImage3D
+    #elif defined(GL_ALT_FUNDEF_TexImage3DEXT)
+    #define TexImage3DFunc glTexImage3DEXT
+    #else
+    #error no declaration of glTexImage3D found
+    #endif
+    
 	void Image3D(GLenum targ,GLint level,GLint internalformat, GLsizei width, GLsizei height, GLsizei depth,GLint border, GLenum format, GLenum type, const GLvoid *data)
 	{
 		m_target = targ;
-		texture_function_dsa(glTextureImage3DEXT,glTexImage3D,targ,level,internalformat,width,height,depth,border,format,type,data);
+		texture_function_dsa(glTextureImage3DEXT,TexImage3DFunc,targ,level,internalformat,width,height,depth,border,format,type,data);
 	}
 	void Image3D(GLint level,GLint internalformat, GLsizei width, GLsizei height, GLsizei depth,GLint border, GLenum format, GLenum type, const GLvoid *data)
 	{
 		m_target = GL_TEXTURE_3D;
-		texture_function_dsa(glTextureImage3DEXT,glTexImage3D,m_target,level,internalformat,width,height,depth,border,format,type,data);
+		texture_function_dsa(glTextureImage3DEXT,TexImage3DFunc,m_target,level,internalformat,width,height,depth,border,format,type,data);
 	}
     #endif
 	
@@ -923,16 +961,25 @@ GLenum type, const GLvoid *data)
 	}
   #endif
 
-    #if defined(GL_ALT_FUNDEF_TexSubImage3D) || defined(GL_ALT_FUNDEF_TextureSubImage3DEXT)
+    #if defined(GL_ALT_FUNDEF_TexSubImage3D) || defined(GL_ALT_FUNDEF_TextureSubImage3DEXT) || defined(GL_ALT_FUNDEF_TexSubImage3DEXT)
+    
+    #if defined(GL_ALT_FUNDEF_TexSubImage3D)
+    #define TexSubImage3DFunc glTexSubImage3D
+    #elif defined(GL_ALT_FUNDEF_TexSubImage3DEXT)
+    #define TexSubImage3DFunc glTexSubImage3DEXT
+    #else
+    #error no declaration of glTexSubImage3D found
+    #endif
+    
 	void SubImage3D(GLenum targ, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format,
 GLenum type, const GLvoid *data)
 	{
-		texture_function_dsa(glTextureSubImage3DEXT,glTexSubImage3D,targ,level,xoffset,yoffset,zoffset,width,height,depth,format,type,data);
+		texture_function_dsa(glTextureSubImage3DEXT,TexSubImage3DFunc,targ,level,xoffset,yoffset,zoffset,width,height,depth,format,type,data);
 	}
 	void SubImage3D(GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, 
 GLenum type, const GLvoid *data)
 	{
-		texture_function_dsa(glTextureSubImage3DEXT,glTexSubImage3D,m_target,level,xoffset,yoffset,zoffset,width,height,depth,format,type,data);
+		texture_function_dsa(glTextureSubImage3DEXT,TexSubImage3DFunc,m_target,level,xoffset,yoffset,zoffset,width,height,depth,format,type,data);
 	}
     #endif
 	
@@ -959,88 +1006,156 @@ GLenum type, const GLvoid *data)
 	}
     #endif
     
-    #if defined(GL_ALT_FUNDEF_CopyTexSubImage3D) || defined(GL_ALT_FUNDEF_CopyTextureSubImage3DEXT)
+    #if defined(GL_ALT_FUNDEF_CopyTexSubImage3D) || defined(GL_ALT_FUNDEF_CopyTextureSubImage3DEXT) || defined(GL_ALT_FUNDEF_CopyTexSubImage3DEXT)
+    
+    #if defined(GL_ALT_FUNDEF_CopyTexSubImage3D)
+    #define CopyTexSubImage3DFunc glCopyTexSubImage3D
+    #elif defined(GL_ALT_FUNDEF_CopyTexSubImage3DEXT)
+    #define CopyTexSubImage3DFunc glCopyTexSubImage3DEXT
+    #else
+    #error no declaration of CopyTexSubImage3D found
+    #endif
+    
+    
 	void CopySubImage3D(GLenum targ,GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLint x, GLint y, GLsizei width, GLsizei height)
 	{
-		texture_function_dsa(glCopyTextureSubImage3DEXT,glCopyTexSubImage3D,targ,level,xoffset,yoffset,zoffset,x,y,width,height);
+		texture_function_dsa(glCopyTextureSubImage3DEXT,CopyTexSubImage3DFunc,targ,level,xoffset,yoffset,zoffset,x,y,width,height);
 	}
 	void CopySubImage3D(GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLint x, GLint y, GLsizei width, GLsizei height)
 	{
-		texture_function_dsa(glCopyTextureSubImage3DEXT,glCopyTexSubImage3D,m_target,level,xoffset,yoffset,zoffset,x,y,width,height);
+		texture_function_dsa(glCopyTextureSubImage3DEXT,CopyTexSubImage3DFunc,m_target,level,xoffset,yoffset,zoffset,x,y,width,height);
 	}
     #endif
     
-    #if defined(GL_ALT_FUNDEF_CompressedTexImage1D) || defined(GL_ALT_FUNDEF_CompressedTextureImage1DEXT)
+    #if defined(GL_ALT_FUNDEF_CompressedTexImage1D) || defined(GL_ALT_FUNDEF_CompressedTextureImage1DEXT) || defined(GL_ALT_FUNDEF_CompressedTexImage1DARB)
+    
+    #if defined(GL_ALT_FUNDEF_CompressedTexImage1D)
+        #define CompressedTexImage1DFunc glCompressedTexImage1D
+    #elif defined(GL_ALT_FUNDEF_CompressedTexImage1DARB)
+        #define CompressedTexImage1DFunc glCompressedTexImage1DARB
+    #else
+        #error no declaration of CompressedTexImage1D found
+    #endif
+    
 	void CompressedImage1D(GLenum targ,GLint level,GLenum internalformat,GLsizei width, GLint border, GLsizei imagesize,const void* data)
 	{
-		texture_function_dsa(glCompressedTextureImage1DEXT, glCompressedTexImage1D, targ, level, internalformat, width, border, imagesize, data);
+		texture_function_dsa(glCompressedTextureImage1DEXT, CompressedTexImage1DFunc, targ, level, internalformat, width, border, imagesize, data);
 	}
 	void CompressedImage1D(GLint level,GLenum internalformat,GLsizei width, GLint border, GLsizei imagesize,const void* data)
 	{
-		texture_function_dsa(glCompressedTextureImage1DEXT, glCompressedTexImage1D, m_target, level, internalformat, width, border, imagesize, data);
+		texture_function_dsa(glCompressedTextureImage1DEXT, CompressedTexImage1DFunc, m_target, level, internalformat, width, border, imagesize, data);
 	}
     #endif
     
-     #if defined(GL_ALT_FUNDEF_CompressedTexImage2D) || defined(GL_ALT_FUNDEF_CompressedTextureImage2DEXT)
-	void CompressedImage2D(GLenum targ,GLint level, GLenum internalformat, 
+    #if defined(GL_ALT_FUNDEF_CompressedTexImage2D) || defined(GL_ALT_FUNDEF_CompressedTextureImage2DEXT) || defined(GL_ALT_FUNDEF_CompressedTexImage2DARB)
+
+    #if defined(GL_ALT_FUNDEF_CompressedTexImage2D)
+    #define CompressedTexImage2DFunc glCompressedTexImage2D
+    #elif defined(GL_ALT_FUNDEF_CompressedTexImage2DARB)
+    #define CompressedTexImage2DFunc glCompressedTexImage2DARB
+    #else
+    #error no declaration of CompressedTexImage2D found
+    #endif
+    
+	void CompressedImage2D(GLenum targ,GLint level, GLenum internalformat,
 GLsizei width, GLsizei height, GLint border, 
 GLsizei imagesize, const void *data)
 	{
-		texture_function_dsa(glCompressedTextureImage2DEXT, glCompressedTexImage2D, targ, level, internalformat, width, height, border, imagesize, data);
+		texture_function_dsa(glCompressedTextureImage2DEXT, CompressedTexImage2DFunc, targ, level, internalformat, width, height, border, imagesize, data);
 	}
 	void CompressedImage2D(GLint level, GLenum internalformat, 
 GLsizei width, GLsizei height, GLint border, 
 GLsizei imagesize, const void *data)
 	{
-		texture_function_dsa(glCompressedTextureImage2DEXT, glCompressedTexImage2D, m_target, level, internalformat, width, height, border, imagesize, data);
+		texture_function_dsa(glCompressedTextureImage2DEXT, CompressedTexImage2DFunc, m_target, level, internalformat, width, height, border, imagesize, data);
 	}
     #endif
     
-     #if defined(GL_ALT_FUNDEF_CompressedTexImage3D) || defined(GL_ALT_FUNDEF_CompressedTextureImage3DEXT)
-	void CompressedImage3D(GLenum targ,GLint level, GLenum internalformat, 
+    #if defined(GL_ALT_FUNDEF_CompressedTexImage3D) || defined(GL_ALT_FUNDEF_CompressedTextureImage3DEXT) || defined(GL_ALT_FUNDEF_CompressedTexImage3DARB)
+    
+    
+    #if defined(GL_ALT_FUNDEF_CompressedTexImage3D)
+    #define CompressedTexImage3DFunc glCompressedTexImage3D
+    #elif defined(GL_ALT_FUNDEF_CompressedTexImage3DARB)
+    #define CompressedTexImage3DFunc glCompressedTexImage3DARB
+    #else
+    #error no declaration of CompressedTexImage3D found
+    #endif
+    
+	void CompressedImage3D(GLenum targ,GLint level, GLenum internalformat,
 GLsizei width, GLsizei height, GLsizei depth, GLint border, 
 GLsizei imagesize, const void *data)
 	{
-		texture_function_dsa(glCompressedTextureImage3DEXT, glCompressedTexImage3D, targ, level, internalformat, width, height, depth, border, imagesize, data);
+		texture_function_dsa(glCompressedTextureImage3DEXT, CompressedTexImage3DFunc, targ, level, internalformat, width, height, depth, border, imagesize, data);
 	}
 	void CompressedImage3D(GLint level, GLenum internalformat, 
 GLsizei width, GLsizei height, GLsizei depth, GLint border, 
 GLsizei imagesize, const void *data)
 	{
-		texture_function_dsa(glCompressedTextureImage3DEXT, glCompressedTexImage3D, m_target, level, internalformat, width, height, depth, border, imagesize, data);
+		texture_function_dsa(glCompressedTextureImage3DEXT, CompressedTexImage3DFunc, m_target, level, internalformat, width, height, depth, border, imagesize, data);
 	}
     #endif
     
-    #if defined(GL_ALT_FUNDEF_CompressedTexSubImage1D) || defined(GL_ALT_FUNDEF_CompressedTextureSubImage1DEXT)
+    #if defined(GL_ALT_FUNDEF_CompressedTexSubImage1D) || defined(GL_ALT_FUNDEF_CompressedTextureSubImage1DEXT) ||defined(GL_ALT_FUNDEF_CompressedTexSubImage1DARB)
+    
+    
+    #if defined(GL_ALT_FUNDEF_CompressedTexSubImage1D)
+    #define CompressedTexSubImage1DFunc glCompressedTexSubImage1D
+    #elif defined(GL_ALT_FUNDEF_CompressedTexSubImage1DARB)
+    #define CompressedTexSubImage1DFunc glCompressedTexSubImage1DARB
+    #else
+    #error no declaration of CompressedTexSubImage1D found
+    #endif
+    
+    
 	void CompressedSubImage1D(GLenum targ, GLint level, GLint xoffset,GLsizei width, GLenum format, GLsizei imagesize, const void *data)
 	{
-		texture_function_dsa(glCompressedTextureSubImage1DEXT,glCompressedTexSubImage1D,targ,level,xoffset,width,format,imagesize,data);
+		texture_function_dsa(glCompressedTextureSubImage1DEXT,CompressedTexSubImage1DFunc,targ,level,xoffset,width,format,imagesize,data);
 	}
 	void CompressedSubImage1D(GLint level, GLint xoffset,GLsizei width, GLenum format, GLsizei imagesize, const void *data)
 	{
-		texture_function_dsa(glCompressedTextureSubImage1DEXT,glCompressedTexSubImage1D,m_target,level,xoffset,width,format,imagesize,data);
+		texture_function_dsa(glCompressedTextureSubImage1DEXT,CompressedTexSubImage1DFunc,m_target,level,xoffset,width,format,imagesize,data);
 	}
     #endif
     
-    #if defined(GL_ALT_FUNDEF_CompressedTexSubImage2D) || defined(GL_ALT_FUNDEF_CompressedTextureSubImage2DEXT)
+    #if defined(GL_ALT_FUNDEF_CompressedTexSubImage2D) || defined(GL_ALT_FUNDEF_CompressedTextureSubImage2DEXT) || defined(GL_ALT_FUNDEF_CompressedTexSubImage2DARB)
+    
+    
+    #if defined(GL_ALT_FUNDEF_CompressedTexSubImage2D)
+    #define CompressedTexSubImage2DFunc glCompressedTexSubImage2D
+    #elif defined(GL_ALT_FUNDEF_CompressedTexSubImage2DARB)
+    #define CompressedTexSubImage2DFunc glCompressedTexSubImage2DARB
+    #else
+    #error no declaration of CompressedTexSubImage2D found
+    #endif
+    
     void CompressedSubImage2D(GLenum targ, GLint level, GLint xoffset,GLint yoffset,GLsizei width,GLsizei height, GLenum format, GLsizei imagesize, const void *data)
 	{
-		texture_function_dsa(glCompressedTextureSubImage2DEXT,glCompressedTexSubImage2D,targ,level,xoffset,yoffset,width,height,format,imagesize,data);
+		texture_function_dsa(glCompressedTextureSubImage2DEXT,CompressedTexSubImage2DFunc,targ,level,xoffset,yoffset,width,height,format,imagesize,data);
 	}
 	void CompressedSubImage2D(GLint level, GLint xoffset,GLint yoffset,GLsizei width,GLsizei height, GLenum format, GLsizei imagesize, const void *data)
 	{
-		texture_function_dsa(glCompressedTextureSubImage2DEXT,glCompressedTexSubImage2D,m_target,level,xoffset,yoffset,width,height,format,imagesize,data);
+		texture_function_dsa(glCompressedTextureSubImage2DEXT,CompressedTexSubImage2DFunc,m_target,level,xoffset,yoffset,width,height,format,imagesize,data);
 	}
     #endif
     
-    #if defined(GL_ALT_FUNDEF_CompressedTexSubImage3D) || defined(GL_ALT_FUNDEF_CompressedTextureSubImage3DEXT)
+    #if defined(GL_ALT_FUNDEF_CompressedTexSubImage3D) || defined(GL_ALT_FUNDEF_CompressedTextureSubImage3DEXT) || defined(GL_ALT_FUNDEF_CompressedTexSubImage3DARB)
+    
+    #if defined(GL_ALT_FUNDEF_CompressedTexSubImage3D)
+    #define CompressedTexSubImage3DFunc glCompressedTexSubImage3D
+    #elif defined(GL_ALT_FUNDEF_CompressedTexSubImage3DARB)
+    #define CompressedTexSubImage3DFunc glCompressedTexSubImage3DARB
+    #else
+    #error no declaration of CompressedTexSubImage3D found
+    #endif
+    
 	void CompressedSubImage3D(GLenum targ, GLint level, GLint xoffset,GLint yoffset,GLint zoffset,GLsizei width,GLsizei height, GLsizei depth, GLenum format, GLsizei imagesize, const void *data)
 	{
-		texture_function_dsa(glCompressedTextureSubImage3DEXT,glCompressedTexSubImage3D,targ,level,xoffset,yoffset,zoffset,width,height,depth,format,imagesize,data);
+		texture_function_dsa(glCompressedTextureSubImage3DEXT,CompressedTexSubImage3DFunc,targ,level,xoffset,yoffset,zoffset,width,height,depth,format,imagesize,data);
 	}
 	void CompressedSubImage3D(GLint level, GLint xoffset,GLint yoffset,GLint zoffset,GLsizei width,GLsizei height, GLsizei depth,GLenum format, GLsizei imagesize, const void *data)
 	{
-		texture_function_dsa(glCompressedTextureSubImage3DEXT,glCompressedTexSubImage3D,m_target,level,xoffset,yoffset,zoffset,width,height,depth,format,imagesize,data);
+		texture_function_dsa(glCompressedTextureSubImage3DEXT,CompressedTexSubImage3DFunc,m_target,level,xoffset,yoffset,zoffset,width,height,depth,format,imagesize,data);
 	}
     #endif
     
@@ -1059,23 +1174,39 @@ boolean fixedsamplelocations);
 
 	*/
     
-    #if defined(GL_ALT_FUNDEF_TexBuffer) || defined(GL_ALT_FUNDEF_TextureBufferEXT)
+    #if defined(GL_ALT_FUNDEF_TexBuffer) || defined(GL_ALT_FUNDEF_TextureBufferEXT) || defined(GL_ALT_FUNDEF_TexBufferEXT)
+    
+    #if defined(GL_ALT_FUNDEF_TexBuffer)
+    #define GL_ALT_TexBufferFunc glTexBuffer
+    #elif defined(GL_ALT_FUNDEF_TexBufferEXT)
+    #define GL_ALT_TexBufferFunc glTexBufferEXT
+    #else
+    #error No declaration of glTexBuffer found ///\todo overload the dsa funcs to allow dsa only mode
+    #endif
+    
 	void Buffer(GLenum targ,GLenum internalformat, GLuint buffer)
-	{
-		texture_function_dsa(glTextureBufferEXT,glTexBuffer,targ,internalformat,buffer);
+    {
+		texture_function_dsa(glTextureBufferEXT,GL_ALT_TexBufferFunc,targ,internalformat,buffer);
 	}
-	void Buffer(GLenum targ,GLenum internalformat,const gl::Buffer& buf)
+    
+    #if defined(GL_ALT_FUNDEF_GenBuffers)
+    void Buffer(GLenum targ,GLenum internalformat,const gl::Buffer& buf)
 	{
 		this->Buffer(targ,internalformat,buf.name);
 	}
+    #endif
+    
 	void Buffer(GLenum internalformat, GLuint buffer)
 	{
-		texture_function_dsa(glTextureBufferEXT,glTexBuffer,m_target,internalformat,buffer);
+		texture_function_dsa(glTextureBufferEXT,GL_ALT_TexBufferFunc,m_target,internalformat,buffer);
 	}
+    
+    #if defined(GL_ALT_FUNDEF_GenBuffers)
 	void Buffer(GLenum internalformat,const gl::Buffer& buf)
 	{
 		this->Buffer(m_target,internalformat,buf.name);
 	}
+    #endif
     #endif
     
     #if defined(GL_ALT_FUNDEF_TexBufferRange) || defined(GL_ALT_FUNDEF_TextureBufferRangeEXT)
@@ -1083,18 +1214,26 @@ boolean fixedsamplelocations);
 	{
 		texture_function_dsa(glTextureBufferRangeEXT,glTexBufferRange,targ,internalformat,buffer,offset,size);
 	}
-	void BufferRange(GLenum targ,GLenum internalformat,const gl::Buffer& buf,GLintptr offset,GLsizeiptr size)
+	
+    #if defined(GL_ALT_FUNDEF_GenBuffers)
+    void BufferRange(GLenum targ,GLenum internalformat,const gl::Buffer& buf,GLintptr offset,GLsizeiptr size)
 	{
 		BufferRange(targ,internalformat,buf.name,offset,size);
 	}
+    #endif
+    
 	void BufferRange(GLenum internalformat,GLuint buffer,GLintptr offset,GLsizeiptr size)
 	{
 		texture_function_dsa(glTextureBufferRangeEXT,glTexBufferRange,m_target,internalformat,buffer,offset,size);
 	}
-	void BufferRange(GLenum internalformat,const gl::Buffer& buf,GLintptr offset,GLsizeiptr size)
+	
+    #if defined(GL_ALT_FUNDEF_GenBuffers)
+    void BufferRange(GLenum internalformat,const gl::Buffer& buf,GLintptr offset,GLsizeiptr size)
 	{
 		BufferRange(m_target,internalformat,buf.name,offset,size);
 	}
+    #endif
+    
     #endif
     
     #if defined(GL_ALT_FUNDEF_TexParameteri) || defined(GL_ALT_FUNDEF_TextureParameteriEXT)
@@ -1142,25 +1281,46 @@ boolean fixedsamplelocations);
 	}
     #endif
     
-    #if defined(GL_ALT_FUNDEF_TexParameterIiv) || defined(GL_ALT_FUNDEF_TextureParameterIivEXT)
+    #if defined(GL_ALT_FUNDEF_TexParameterIiv) || defined(GL_ALT_FUNDEF_TextureParameterIivEXT) || defined(GL_ALT_FUNDEF_TexParameterIivEXT)
+    
+    #if defined(GL_ALT_FUNDEF_TexParameterIiv)
+    #define GL_ALT_TexParameterIivFunc glTexParameterIiv
+    #else
+    #if defined(GL_ALT_FUNDEF_TexParameterIivEXT)
+    #define GL_ALT_TexParameterIivFunc glTexParameterIivEXT
+    #else
+    #error no declaration found for TexParameterIiv
+    #endif
+    #endif
 	void ParameterI(GLenum targ,GLenum pname,const GLint* params)
 	{
-		texture_function_dsa(&glTextureParameterIivEXT,&glTexParameterIiv,targ,pname,params);
+		texture_function_dsa(&glTextureParameterIivEXT,&GL_ALT_TexParameterIivFunc,targ,pname,params);
 	}
 	void ParameterI(GLenum pname,const GLint* params)
 	{
-		texture_function_dsa(&glTextureParameterIivEXT,&glTexParameterIiv,m_target,pname,params);
+		texture_function_dsa(&glTextureParameterIivEXT,&GL_ALT_TexParameterIivFunc,m_target,pname,params);
 	}
     #endif
     
-    #if defined(GL_ALT_FUNDEF_TexParameterIuiv) || defined(GL_ALT_FUNDEF_TextureParameterIuivEXT)
+    #if defined(GL_ALT_FUNDEF_TexParameterIuiv) || defined(GL_ALT_FUNDEF_TextureParameterIuivEXT)|| defined(GL_ALT_FUNDEF_TexParameterIuivEXT)
+    
+    #if defined(GL_ALT_FUNDEF_TexParameterIuiv)
+    #define GL_ALT_TexParameterIiuvFunc glTexParameterIuiv
+    #else
+    #if defined(GL_ALT_FUNDEF_TexParameterIuivEXT)
+    #define GL_ALT_TexParameterIiuvFunc glTexParameterIuivEXT
+    #else
+    #error no declaration found for TexParameterIuiv
+    #endif
+    #endif
+    
 	void ParameterI(GLenum targ,GLenum pname,const GLuint* params)
 	{
-		texture_function_dsa(&glTextureParameterIuivEXT,&glTexParameterIuiv,targ,pname,params);
+		texture_function_dsa(&glTextureParameterIuivEXT,&GL_ALT_TexParameterIiuvFunc,targ,pname,params);
 	}
 	void ParameterI(GLenum pname,const GLuint* params)
 	{
-		texture_function_dsa(&glTextureParameterIuivEXT,&glTexParameterIuiv,m_target,pname,params);
+		texture_function_dsa(&glTextureParameterIuivEXT,&GL_ALT_TexParameterIiuvFunc,m_target,pname,params);
 	}
     #endif
 	
@@ -1193,14 +1353,23 @@ boolean fixedsamplelocations);
 	}
     #endif
     
-    #if defined(GL_ALT_FUNDEF_GetCompressedTexImage) || defined(GL_ALT_FUNDEF_GetCompressedTextureImage)
+    #if defined(GL_ALT_FUNDEF_GetCompressedTexImage) || defined(GL_ALT_FUNDEF_GetCompressedTextureImage)  || defined(GL_ALT_FUNDEF_GetCompressedTexImageARB)
+    
+    #if defined(GL_ALT_FUNDEF_GetCompressedTexImage)
+    #define GetCompressedTexImageFunc glGetCompressedTexImage
+    #elif defined(GL_ALT_FUNDEF_GetCompressedTexImageARB)
+    #define GetCompressedTexImageFunc glGetCompressedTexImageARB
+    #else
+    #error no declaration of GetCompressedTexImage found
+    #endif
+    
 	void GetCompressedImage(GLenum targ,GLint lod, GLvoid *img)
 	{
-		texture_function_dsa(&glGetCompressedTextureImage,&glGetCompressedTexImage,targ,lod,img);
+		texture_function_dsa(&glGetCompressedTextureImage,&GetCompressedTexImageFunc,targ,lod,img);
 	}
 	void GetCompressedImage(GLint lod, GLvoid *img)
 	{
-		texture_function_dsa(&glGetCompressedTextureImage,&glGetCompressedTexImage,m_target,lod,img);
+		texture_function_dsa(&glGetCompressedTextureImage,&GetCompressedTexImageFunc,m_target,lod,img);
 	}
     #endif
     
@@ -1235,36 +1404,66 @@ boolean fixedsamplelocations);
 	}
     #endif
 	
-    #if defined(GL_ALT_FUNDEF_TexStorage1D) || defined(GL_ALT_FUNDEF_TextureStorage1DEXT)
+    #if defined(GL_ALT_FUNDEF_TexStorage1D) || defined(GL_ALT_FUNDEF_TextureStorage1DEXT) || defined(GL_ALT_FUNDEF_TexStorage1DEXT)
+    
+    #if defined(GL_ALT_FUNDEF_TexStorage1D)
+    #define GL_ALT_TexStorage1DFunc glTexStorage1D
+    #elif defined(GL_ALT_FUNDEF_TexStorage1DEXT)
+    #define GL_ALT_TexStorage1DFunc glTexStorage1DEXT
+    #else
+    #error No declaration of glTexStorage1D found ///\todo overload the dsa funcs to allow dsa only mode
+    #endif
+    
+    
 	void Storage1D(GLenum targ, GLsizei levels, GLenum internalformat, GLsizei width)
 	{
-		texture_function_dsa(&glTextureStorage1DEXT,&glTexStorage1D,targ,levels,internalformat,width);
+		texture_function_dsa(&glTextureStorage1DEXT,&GL_ALT_TexStorage1DFunc,targ,levels,internalformat,width);
 	}
 	void Storage1D(GLsizei levels, GLenum internalformat, GLsizei width)
 	{
-		texture_function_dsa(&glTextureStorage1DEXT,&glTexStorage1D,m_target,levels,internalformat,width);
+		texture_function_dsa(&glTextureStorage1DEXT,&GL_ALT_TexStorage1DFunc,m_target,levels,internalformat,width);
 	}
     #endif
     
-    #if defined(GL_ALT_FUNDEF_TexStorage2D) || defined(GL_ALT_FUNDEF_TextureStorage2DEXT)
+    #if defined(GL_ALT_FUNDEF_TexStorage2D) || defined(GL_ALT_FUNDEF_TextureStorage2DEXT) || defined(GL_ALT_FUNDEF_TexStorage2DEXT)
+    
+    
+    
+    #if defined(GL_ALT_FUNDEF_TexStorage2D)
+    #define GL_ALT_TexStorage2DFunc glTexStorage2D
+    #elif defined(GL_ALT_FUNDEF_TexStorage2DEXT)
+    #define GL_ALT_TexStorage2DFunc glTexStorage2DEXT
+    #else
+    #error No declaration of glTexStorage2D found ///\todo overload the dsa funcs to allow dsa only mode
+    #endif
+    
 	void Storage2D(GLenum targ, GLsizei levels, GLenum internalformat, GLsizei width,GLsizei height)
 	{
-		texture_function_dsa(&glTextureStorage2DEXT,&glTexStorage2D,targ,levels,internalformat,width,height);
+		texture_function_dsa(&glTextureStorage2DEXT,&GL_ALT_TexStorage2DFunc,targ,levels,internalformat,width,height);
 	}
 	void Storage2D(GLsizei levels, GLenum internalformat, GLsizei width,GLsizei height)
 	{
-		texture_function_dsa(&glTextureStorage2DEXT,&glTexStorage2D,m_target,levels,internalformat,width,height);
+		texture_function_dsa(&glTextureStorage2DEXT,&GL_ALT_TexStorage2DFunc,m_target,levels,internalformat,width,height);
 	}
     #endif
     
-    #if defined(GL_ALT_FUNDEF_TexStorage3D) || defined(GL_ALT_FUNDEF_TextureStorage3DEXT)
+    #if defined(GL_ALT_FUNDEF_TexStorage3D) || defined(GL_ALT_FUNDEF_TextureStorage3DEXT) || defined(GL_ALT_FUNDEF_TexStorage3D)
+    
+    #if defined(GL_ALT_FUNDEF_TexStorage3D)
+    #define GL_ALT_TexStorage3DFunc glTexStorage3D
+    #elif defined(GL_ALT_FUNDEF_TexStorage3DEXT)
+    #define GL_ALT_TexStorage3DFunc glTexStorage3DEXT
+    #else
+    #error No declaration of glTexStorage3D found ///\todo overload the dsa funcs to allow dsa only mode
+    #endif
+    
 	void Storage3D(GLenum targ, GLsizei levels, GLenum internalformat, GLsizei width,GLsizei height,GLsizei depth)
 	{
-		texture_function_dsa(&glTextureStorage3DEXT,&glTexStorage3D,targ,levels,internalformat,width,height,depth);
+		texture_function_dsa(&glTextureStorage3DEXT,&GL_ALT_TexStorage3DFunc,targ,levels,internalformat,width,height,depth);
 	}
 	void Storage3D(GLsizei levels, GLenum internalformat, GLsizei width,GLsizei height,GLsizei depth)
 	{
-		texture_function_dsa(&glTextureStorage3DEXT,&glTexStorage3D,m_target,levels,internalformat,width,height,depth);
+		texture_function_dsa(&glTextureStorage3DEXT,&GL_ALT_TexStorage3DFunc,m_target,levels,internalformat,width,height,depth);
 	}
     #endif
 	/*Can't be dsaed
@@ -1520,14 +1719,26 @@ public:
 	}
     #endif
 	
-    #if defined(GL_ALT_FUNDEF_NamedFramebufferTextureEXT) || defined(GL_ALT_FUNDEF_FramebufferTexture)
+    #if (defined(GL_ALT_FUNDEF_NamedFramebufferTextureEXT) || defined(GL_ALT_FUNDEF_FramebufferTexture) || defined(GL_ALT_FUNDEF_FramebufferTextureEXT)) && defined(GL_ALT_FUNDEF_GenTextures)
+    
+    #if defined(GL_ALT_FUNDEF_FramebufferTexture)
+    #define FramebufferTextureFunc glFramebufferTexture
+    #elif defined(GL_ALT_FUNDEF_FramebufferTextureEXT)
+    #define FramebufferTextureFunc glFramebufferTextureEXT
+    #else
+    #error No declaration of glFramebufferTextureFunc found ///\todo overload the dsa funcs to allow dsa only mode
+    #endif
+    
 	void Texture(GLenum attachment, GLuint texture, GLint level)
 	{
-		framebuffer_function_dsa(&glNamedFramebufferTextureEXT,&glFramebufferTexture,attachment,texture,level);
+        
+        
+		framebuffer_function_dsa(&glNamedFramebufferTextureEXT,&FramebufferTextureFunc,attachment,texture,level);
 	}
+    
 	void Texture(GLenum attachment,const gl::Texture& tex, GLint level)
 	{
-		framebuffer_function_dsa(&glNamedFramebufferTextureEXT,&glFramebufferTexture,attachment,tex.name,level);
+		framebuffer_function_dsa(&glNamedFramebufferTextureEXT,&FramebufferTextureFunc,attachment,tex.name,level);
 	}
     #endif
 
@@ -1536,7 +1747,7 @@ public:
 	void Renderbuffer(GLenum attachment,const gl::Renderbuffer& rb, GLint level);
     #endif
 
-    #if defined(GL_ALT_FUNDEF_FramebufferTexture1D) || defined(GL_ALT_FUNDEF_NamedFramebufferTexture1DEXT)
+    #if (defined(GL_ALT_FUNDEF_FramebufferTexture1D) || defined(GL_ALT_FUNDEF_NamedFramebufferTexture1DEXT)) && defined(GL_ALT_FUNDEF_GenTextures)
 	void Texture1D(GLenum attachment, GLenum textarget, GLuint texture, GLint level)
 	{
 		framebuffer_function_dsa(&glNamedFramebufferTexture1DEXT, &glFramebufferTexture1D, attachment, textarget, texture, level);
@@ -1547,7 +1758,7 @@ public:
 	}
     #endif
     
-    #if defined(GL_ALT_FUNDEF_FramebufferTexture2D) || defined(GL_ALT_FUNDEF_NamedFramebufferTexture2DEXT)
+    #if (defined(GL_ALT_FUNDEF_FramebufferTexture2D) || defined(GL_ALT_FUNDEF_NamedFramebufferTexture2DEXT)) && defined(GL_ALT_FUNDEF_GenTextures)
 	void Texture2D(GLenum attachment, GLenum textarget, GLuint texture, GLint level)
 	{
 		framebuffer_function_dsa(&glNamedFramebufferTexture2DEXT, &glFramebufferTexture2D, attachment, textarget, texture, level);
@@ -1558,7 +1769,7 @@ public:
 	}
     #endif
     
-    #if defined(GL_ALT_FUNDEF_FramebufferTexture3D) || defined(GL_ALT_FUNDEF_NamedFramebufferTexture3DEXT)
+    #if (defined(GL_ALT_FUNDEF_FramebufferTexture3D) || defined(GL_ALT_FUNDEF_NamedFramebufferTexture3DEXT))&& defined(GL_ALT_FUNDEF_GenTextures)
 	void Texture3D(GLenum attachment, GLenum textarget, GLuint texture, GLint level,GLint layer)
 	{
 		framebuffer_function_dsa(&glNamedFramebufferTexture3DEXT, &glFramebufferTexture3D, attachment, textarget, texture, level, layer);
@@ -1613,10 +1824,20 @@ public:
 	}
     #endif
 	
-    #if defined(GL_ALT_FUNDEF_NamedRenderbufferStorageMultisampleEXT) || defined(GL_ALT_FUNDEF_RenderbufferStorageMultisampleEXT)
+    #if defined(GL_ALT_FUNDEF_NamedRenderbufferStorageMultisampleEXT) || defined(GL_ALT_FUNDEF_RenderbufferStorageMultisampleEXT) || defined (GL_ALT_FUNDEF_RenderbufferStorageMultisample)
+    
+    
+    #if defined(GL_ALT_FUNDEF_RenderbufferStorageMultisample)
+    #define GL_ALT_RenderbufferStorageMultisampleFunc glRenderbufferStorageMultisample
+    #elif defined(GL_ALT_FUNDEF_RenderbufferStorageMultisampleEXT)
+    #define GL_ALT_RenderbufferStorageMultisampleFunc glRenderbufferStorageMultisampleEXT
+    #else
+    #error No declaration of RenderbufferStorageMultisample found ///\todo overload the dsa funcs to allow dsa only mode
+    #endif
+    
 	void StorageMultisample(GLsizei samples,GLenum internalformat, GLsizei width, GLsizei height)
 	{
-		renderbuffer_function_dsa(&glNamedRenderbufferStorageMultisampleEXT,&glRenderbufferStorageMultisample,samples,internalformat,width,height);
+		renderbuffer_function_dsa(&glNamedRenderbufferStorageMultisampleEXT,&GL_ALT_RenderbufferStorageMultisampleFunc,samples,internalformat,width,height);
 	}
     #endif
     
@@ -1647,12 +1868,12 @@ protected:
 #if defined(GL_ALT_FUNDEF_NamedFramebufferRenderbuffer) || defined(GL_ALT_FUNDEF_NamedFramebufferRenderbufferEXT)
 void Framebuffer::Renderbuffer(GLenum attachment, GLuint renderbuffer, GLint level)
 {
-	framebuffer_function_dsa(&glNamedFramebufferRenderbuffer,&glFramebufferRenderbufferEXT,attachment,GL_RENDERBUFFER,renderbuffer);
+	framebuffer_function_dsa(&glNamedFramebufferRenderbuffer,&glFramebufferRenderbuffer,attachment,GL_RENDERBUFFER,renderbuffer);
 }
 
 void Framebuffer::Renderbuffer(GLenum attachment,const gl::Renderbuffer& rb, GLint level)
 {
-	framebuffer_function_dsa(&glNamedFramebufferRenderbuffer,&glFramebufferRenderbufferEXT,attachment,GL_RENDERBUFFER,rb.name);
+	framebuffer_function_dsa(&glNamedFramebufferRenderbuffer,&glFramebufferRenderbuffer,attachment,GL_RENDERBUFFER,rb.name);
 }
 #endif
 

--- a/opengl.hpp
+++ b/opengl.hpp
@@ -25,6 +25,7 @@
 #endif*/
 
 #define GL_HPP_CUSTOM 0x0001
+
 namespace gl
 {
 	
@@ -38,25 +39,26 @@ inline bool check_extension(const std::string& ext)
 	return glaltCheckExtension(ext.c_str());
 }
 #endif
-	
-	
-	
+    
+    
 namespace _impl
 {
 void _handleError(GLenum errcode,const std::string& what);
 void _checkError(GLenum errcode,const std::string& what);
 
-template<GLenum ac=GL_READ_WRITE>
+template<GLenum ac=0>
 struct BufferMapType
-{
-	typedef void* ptrtype;
-};
-
-template<>
-struct BufferMapType<GL_READ_ONLY>
 {
 	typedef const void* ptrtype;
 };
+
+#ifdef GL_MAP_WRITE_BIT
+template<>
+struct BufferMapType<GL_MAP_WRITE_BIT>
+{
+	typedef void* ptrtype;
+};
+#endif
 
 template<class Base>
 class DefaultZeroType: public Base
@@ -567,46 +569,85 @@ public:
  	void Bind(GLenum bt) const;
     #endif
 
+    #if defined GL_ALT_FUNDEF_BindBufferRange
 	void BindRange(GLenum target, GLuint index,GLintptr offset, GLsizeiptr size) const;
-	void BindBase(GLenum target,GLuint index) const;
-
+    #endif
+    
+    #ifdef GL_ALT_FUNDEF_BindBufferBase
+    void BindBase(GLenum target,GLuint index) const;
+    #endif
+    
+    #if defined(GL_ALT_FUNDEF_FlushMappedNamedBufferRangeEXT) || defined(GL_ALT_FUNDEF_FlushMappedBufferRange)
 	void FlushMappedRange(GLintptr offset,GLsizeiptr sz) const;
-	void GetSubData(GLintptr offset,GLsizeiptr size,void* output_buffer) const;
-	void* GetMappedPointer() const;
-
+    #endif
+	
+    #if defined(GL_ALT_FUNDEF_GetNamedBufferSubDataEXT) || defined(GL_ALT_FUNDEF_GetBufferSubData)
+    void GetSubData(GLintptr offset,GLsizeiptr size,void* output_buffer) const;
+    #endif
+    
+    #if defined(GL_ALT_FUNDEF_GetNamedBufferPointervEXT) || defined(GL_ALT_FUNDEF_GetBufferPointerv)
+    void* GetMappedPointer() const;
+    #endif
+    
+    #if defined(GL_ALT_FUNDEF_GetNamedBufferParameterivEXT) || defined(GL_ALT_FUNDEF_GetBufferParameteriv)
 	GLint Get(GLenum value) const;
+    #endif
 
-	void Data(GLsizeiptr sz,const GLvoid* data,GLenum usage);
-
-	template<class T>
+    #if defined(GL_ALT_FUNDEF_NamedBufferDataEXT) || defined(GL_ALT_FUNDEF_BindBuffer)
+    void Data(GLsizeiptr sz,const GLvoid* data,GLenum usage);
+    
+    template<class T>
 	void Data(const T* b,const T* e,GLenum usage);
+    #endif
 
+    #if defined(GL_ALT_FUNDEF_NamedBufferSubDataEXT) || defined(GL_ALT_FUNDEF_BufferSubData)
 	void SubData(GLintptr offset,GLsizeiptr size,const GLvoid* data);
-	
+    #endif
+    
+    #ifdef GL_ALT_FUNDEF_ClearBufferData
 	void ClearData(GLenum internalformat,GLenum format,GLenum type,const void* data);
-	void ClearSubData(GLenum internalformat,GLintptr offset,GLsizeiptr size,GLenum format,GLenum type,const void* data);
+    #endif
+    
+    #ifdef GL_ALT_FUNDEF_ClearBufferSubData
+    void ClearSubData(GLenum internalformat,GLintptr offset,GLsizeiptr size,GLenum format,GLenum type,const void* data);
+    #endif
 	
-	void InvalidateData();
+	#ifdef GL_ALT_FUNDEF_InvalidateBufferData
+    void InvalidateData();
+    #endif
+    
+    #ifdef GL_ALT_FUNDEF_InvalidateBufferSubData
 	void InvalidateSubData(GLintptr offset,GLsizeiptr length);
-
+    #endif
+    
 	template<class T>
 	void SubData(GLintptr offset,const T* b,const T* e);
 
+    
+    #if defined(GL_ALT_FUNDEF_MapBuffer) || defined(GL_ALT_FUNDEF_MapNamedBufferEXT)
 	void* Map(GLenum access);
-	
+    
 	template<GLenum ac>
 	typename _impl::BufferMapType<ac>::ptrtype Map();
 
+    #endif
+    
+    #if defined(GL_ALT_FUNDEF_UnmapNamedBufferEXT) || defined(GL_ALT_FUNDEF_UnmapBuffer)
 	bool Unmap();
+    #endif
 
+    #if defined(GL_ALT_FUNDEF_MapBufferRange) || defined(GL_ALT_FUNDEF_MapNamedBufferRangeEXT)
 	void* MapRange(GLintptr offset,GLsizeiptr length,GLbitfield access);
 
-	template<GLbitfield ac>
-	typename _impl::BufferMapType<(ac & GL_MAP_READ_BIT ? ( ac & GL_MAP_WRITE_BIT ? GL_READ_WRITE : GL_READ_ONLY) : GL_WRITE_ONLY)>::ptrtype
+    template<GLbitfield ac>
+	typename _impl::BufferMapType<ac & GL_MAP_WRITE_BIT>::ptrtype
 	MapRange(GLintptr offset,GLsizeiptr length);
-
+    #endif
+    
+    #if defined(GL_ALT_FUNDEF_NamedCopyBufferSubDataEXT) || defined(GL_ALT_FUNDEF_CopyBufferSubData)
 	void CopySubData(const Buffer& read,GLintptr readoffset,GLintptr writeoffset,GLsizeiptr sz);
-	
+    #endif
+    
 	Buffer():
 		_impl::GLObject<Buffer>("GLBuffer",glGenBuffers,glDeleteBuffers)
 	{}
@@ -637,18 +678,20 @@ public:
 	void DisableAttrib(GLuint index);
     #endif
     
+    #if defined(GL_ALT_FUNDEF_VertexArrayVertexAttribOffsetEXT) || defined(GL_ALT_FUNDEF_VertexAttribPointer)
 	void AttribPointer(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const GLvoid * pointer);
-	void AttribIPointer(GLuint index,GLint size,GLenum type,GLsizei stride,const GLvoid * pointer);
-
-	void AttribPointer(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const Buffer& b,GLsizeiptr offset);
-	void AttribIPointer(GLuint index,GLint size,GLenum type,GLsizei stride,const Buffer& b,GLsizeiptr offset);
-
-	void Attrib(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const GLvoid * pointer);
-	void AttribI(GLuint index,GLint size,GLenum type,GLsizei stride,const GLvoid * pointer);
-
+    void AttribPointer(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const Buffer& b,GLsizeiptr offset);
+    void Attrib(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const GLvoid * pointer);
 	void Attrib(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const Buffer& b,GLsizeiptr offset);
+    #endif
+    
+    #if defined(GL_ALT_FUNDEF_VertexArrayVertexAttribIOffsetEXT) || defined(GL_ALT_FUNDEF_VertexAttribIPointer)
+	void AttribIPointer(GLuint index,GLint size,GLenum type,GLsizei stride,const GLvoid * pointer);
+	void AttribIPointer(GLuint index,GLint size,GLenum type,GLsizei stride,const Buffer& b,GLsizeiptr offset);
+	void AttribI(GLuint index,GLint size,GLenum type,GLsizei stride,const GLvoid * pointer);
 	void AttribI(GLuint index,GLint size,GLenum type,GLsizei stride,const Buffer& b,GLsizeiptr offset);
-
+    #endif
+    
     #if defined(GL_ALT_FUNDEF_BindVertexArray) && defined(GL_ALT_FUNDEF_BindBuffer)
 	void Elements(const GLvoid * pointer);///\todo no implementation
 	void Elements(const Buffer&b);
@@ -1441,7 +1484,7 @@ private:
 public:
 	Framebuffer():
 		_impl::GLObject<Framebuffer>("GLFramebuffer",glGenFramebuffers,glDeleteFramebuffers),
-		m_target(GL_DRAW_FRAMEBUFFER)
+		m_target(GL_FRAMEBUFFER)
 	{}
 	
     #if defined(GL_ALT_FUNDEF_BindFramebuffer)
@@ -1599,6 +1642,8 @@ protected:
 	{}
 };
     
+#endif
+    
 #if defined(GL_ALT_FUNDEF_NamedFramebufferRenderbuffer) || defined(GL_ALT_FUNDEF_NamedFramebufferRenderbufferEXT)
 void Framebuffer::Renderbuffer(GLenum attachment, GLuint renderbuffer, GLint level)
 {
@@ -1612,7 +1657,7 @@ void Framebuffer::Renderbuffer(GLenum attachment,const gl::Renderbuffer& rb, GLi
 #endif
 
 }
-#endif
+
 
 #include "opengl.inl"
 

--- a/opengl.inl
+++ b/opengl.inl
@@ -265,12 +265,14 @@ inline std::string Shader::Compile()
 ///////////////////////////////////////////////////////
 //Program Objects
 //direct functions
-#ifndef	GL_ALT_FUNDEF_CreateProgram
+#ifdef GL_ALT_FUNDEF_CreateProgram
     
-#ifndef GL_HPP_DIRECT_STATE
 //This DSA solution is justifiable because an in-cache if statement with crazy branch prediction
 //will always be faster than an out of cache PIMPL paradigm for this.
 //also uses a variadic macro to get function args
+#define FNAME_PASSTHROUGH_MACRO(passthrough) passthrough
+
+#if defined(GL_EXT_direct_state_access)
 #define GL_HPP_UNIFORM_WRAPPER(fn,...)											\
 {																			\
 	if(direct_state_access_supported)												\
@@ -282,63 +284,121 @@ inline std::string Shader::Compile()
 		GLint curr_prog=gl::Get<GLint>(GL_CURRENT_PROGRAM);						\
 		glUseProgram(object);													\
 		_impl::_checkError(GL_INVALID_OPERATION,"Uniformed program could not be made part of current state, or transform feedback mode is enabled");\
-		gl##fn(Program::GetUniformLocation(n),__VA_ARGS__);																		\
+		FNAME_PASSTHROUGH_MACRO(gl##fn)(Program::GetUniformLocation(n),__VA_ARGS__);																		\
 		_impl::checkUniform();													\
 		glUseProgram(curr_prog);												\
 		_impl::_checkError(GL_INVALID_OPERATION,"Uniformed program could not be made part of current state, or transform feedback mode is enabled");\
 	}																			\
 }																			\
-																			\
+																		\
 
+#endif
+//#else
+#if !defined(GL_EXT_direct_state_access)
+    
+#define GL_HPP_UNIFORM_WRAPPER(fn,...)											\
+    {																			\
+        																		\
+        {																			\
+            GLint curr_prog=gl::Get<GLint>(GL_CURRENT_PROGRAM);						\
+            glUseProgram(object);													\
+            _impl::_checkError(GL_INVALID_OPERATION,"Uniformed program could not be made part of current state, or transform feedback mode is enabled");\
+            gl##fn(Program::GetUniformLocation(n),__VA_ARGS__);																		\
+            _impl::checkUniform();													\
+            glUseProgram(curr_prog);												\
+            _impl::_checkError(GL_INVALID_OPERATION,"Uniformed program could not be made part of current state, or transform feedback mode is enabled");\
+        }																			\
+    }																			\
+    \
+    
+#endif
+    
+#if defined(GL_ALT_FUNDEF_ProgramUniform1fEXT) || defined(GL_ALT_FUNDEF_Uniform1f)
 inline void Program::Uniform(const std::string& n,const GLfloat& v1)
-{
+{   
 	GL_HPP_UNIFORM_WRAPPER(Uniform1f,v1);
 }
+#endif
+    
+#if defined (GL_ALT_FUNDEF_Uniform2f) || defined(GL_ALT_FUNDEF_ProgramUniform2fEXT)
 inline void Program::Uniform(const std::string& n,const GLfloat& v1,const GLfloat& v2)
 {
 	GL_HPP_UNIFORM_WRAPPER(Uniform2f,v1,v2);
 }
+#endif
+    
+#if defined(GL_ALT_FUNDEF_Uniform3f) || defined(GL_ALT_FUNDEF_ProgramUniform3fEXT)
 inline void Program::Uniform(const std::string& n,const GLfloat& v1,const GLfloat& v2,const GLfloat& v3)
 {
 	GL_HPP_UNIFORM_WRAPPER(Uniform3f,v1,v2,v3);
 }
+#endif
+    
+#if defined(GL_ALT_FUNDEF_Uniform4f) || defined(GL_ALT_FUNDEF_ProgramUniform4fEXT)
 inline void Program::Uniform(const std::string& n,const GLfloat& v1,const GLfloat& v2,const GLfloat& v3,const GLfloat& v4)
 {
 	GL_HPP_UNIFORM_WRAPPER(Uniform4f,v1,v2,v3,v4);
 }
+#endif
+    
+#if defined(GL_ALT_FUNDEF_ProgramUniform1iEXT) || defined(GL_ALT_FUNDEF_Uniform1i)
 inline void Program::Uniform(const std::string& n,const GLint& v1)
 {
 	GL_HPP_UNIFORM_WRAPPER(Uniform1i,v1);
 }
+#endif
+    
+#if defined(GL_ALT_FUNDEF_Uniform2i) || defined(GL_ALT_FUNDEF_ProgramUniform2iEXT)
 inline void Program::Uniform(const std::string& n,const GLint& v1,const GLint& v2)
 {
 	GL_HPP_UNIFORM_WRAPPER(Uniform2i,v1,v2);
 }
+#endif
+    
+#if defined(GL_ALT_FUNDEF_Uniform3i) || defined(GL_ALT_FUNDEF_ProgramUniform3iEXT)
 inline void Program::Uniform(const std::string& n,const GLint& v1,const GLint& v2,const GLint& v3)
 {
 	GL_HPP_UNIFORM_WRAPPER(Uniform3i,v1,v2,v3);
 }
+#endif
+    
+#if defined(GL_ALT_FUNDEF_Uniform4i) || defined(GL_ALT_FUNDEF_ProgramUniform4iEXT)
 inline void Program::Uniform(const std::string& n,const GLint& v1,const GLint& v2,const GLint& v3,const GLint& v4)
 {
 	GL_HPP_UNIFORM_WRAPPER(Uniform4i,v1,v2,v3,v4);
 }
+#endif
 
+    
+///\todo changing the following preprocessor ifdefs because of ES 2: the programUniform stuff should be ignored in ES 3 but is defined as part of the extension spec; there is no available glUniformXui on ES 2
+    
+#if defined(GL_ALT_FUNDEF_Uniform1ui)
 inline void Program::Uniform(const std::string& n,const GLuint& v1)
 {
 	GL_HPP_UNIFORM_WRAPPER(Uniform1ui,v1);
 }
+#endif
+    
+#if defined(GL_ALT_FUNDEF_Uniform2ui)
 inline void Program::Uniform(const std::string& n,const GLuint& v1,const GLuint& v2)
 {
 	GL_HPP_UNIFORM_WRAPPER(Uniform2ui,v1,v2);
 }
+#endif
+    
+#if defined(GL_ALT_FUNDEF_Uniform3ui)
 inline void Program::Uniform(const std::string& n,const GLuint& v1,const GLuint& v2,const GLuint& v3)
 {
 	GL_HPP_UNIFORM_WRAPPER(Uniform3ui,v1,v2,v3);
 }
+#endif
+    
+#if defined(GL_ALT_FUNDEF_Uniform4ui) 
 inline void Program::Uniform(const std::string& n,const GLuint& v1,const GLuint& v2,const GLuint& v3,const GLuint& v4)
 {
 	GL_HPP_UNIFORM_WRAPPER(Uniform4ui,v1,v2,v3,v4);
 }
+#endif
 
 //matrix and array uniforms
 
@@ -391,20 +451,63 @@ GL_HPP_PROGRAM_UNIFORM_DEFINITION(GLint,3,Uniform3iv);
 GL_HPP_PROGRAM_UNIFORM_DEFINITION(GLint,4,Uniform4iv);
 #endif
     
-#if defined (GL_ALT_FUNDEF_Uniform1uiv) || defined (GL_ALT_FUNDEF_ProgramUniform1uiv)
-GL_HPP_PROGRAM_UNIFORM_DEFINITION(GLuint,1,Uniform1uiv);
+#if defined (GL_ALT_FUNDEF_Uniform1uiv) || defined (GL_ALT_FUNDEF_ProgramUniform1uiv) || defined(GL_ALT_FUNDEF_Uniform1uivEXT)
+    
+#if !defined(GL_ALT_FUNDEF_Uniform1uiv)
+    #if defined(GL_ALT_FUNDEF_Uniform1uivEXT)
+    #define FNAME_PASSTHROUGH_MACRO(passthrough) passthrough##EXT
+    #else
+        #error no declaration of Uniform1uiv found
+    #endif
+#else
+    #define FNAME_PASSTHROUGH_MACRO(passthrough) passthrough
 #endif
     
+GL_HPP_PROGRAM_UNIFORM_DEFINITION(GLuint,1u,Uniform1uiv);
+#define FNAME_PASSTHROUGH_MACRO(passthrough) passthrough
+#endif
+    
+    
 #if defined (GL_ALT_FUNDEF_Uniform2uiv) || defined (GL_ALT_FUNDEF_ProgramUniform2uiv)
-GL_HPP_PROGRAM_UNIFORM_DEFINITION(GLuint,2,Uniform2uiv);
+#if !defined(GL_ALT_FUNDEF_Uniform2uiv)
+#if defined(GL_ALT_FUNDEF_Uniform2uivEXT)
+#define FNAME_PASSTHROUGH_MACRO(passthrough) passthrough##EXT
+#else
+#error no declaration of Uniform1uiv found
+#endif
+#else
+#define FNAME_PASSTHROUGH_MACRO(passthrough) passthrough
+#endif
+GL_HPP_PROGRAM_UNIFORM_DEFINITION(GLuint,2u,Uniform2uiv);
+#define FNAME_PASSTHROUGH_MACRO(passthrough) passthrough
 #endif
 
 #if defined (GL_ALT_FUNDEF_Uniform3uiv) || defined (GL_ALT_FUNDEF_ProgramUniform3uiv)
-GL_HPP_PROGRAM_UNIFORM_DEFINITION(GLuint,3,Uniform3uiv);
+#if !defined(GL_ALT_FUNDEF_Uniform3uiv)
+#if defined(GL_ALT_FUNDEF_Uniform3uivEXT)
+#define FNAME_PASSTHROUGH_MACRO(passthrough) passthrough##EXT
+#else
+#error no declaration of Uniform1uiv found
+#endif
+#else
+#define FNAME_PASSTHROUGH_MACRO(passthrough) passthrough
+#endif
+GL_HPP_PROGRAM_UNIFORM_DEFINITION(GLuint,3u,Uniform3uiv);
+#define FNAME_PASSTHROUGH_MACRO(passthrough) passthrough
 #endif
     
 #if defined (GL_ALT_FUNDEF_Uniform4uiv) ||  defined (GL_ALT_FUNDEF_ProgramUniform4uiv)
-GL_HPP_PROGRAM_UNIFORM_DEFINITION(GLuint,4,Uniform4uiv);
+#if !defined(GL_ALT_FUNDEF_Uniform4uiv)
+#if defined(GL_ALT_FUNDEF_Uniform4uivEXT)
+#define FNAME_PASSTHROUGH_MACRO(passthrough) passthrough##EXT
+#else
+#error no declaration of Uniform1uiv found
+#endif
+#else
+#define FNAME_PASSTHROUGH_MACRO(passthrough) passthrough
+#endif
+GL_HPP_PROGRAM_UNIFORM_DEFINITION(GLuint,4u,Uniform4uiv);
+#define FNAME_PASSTHROUGH_MACRO(passthrough) passthrough
 #endif
     
 #if defined (GL_ALT_FUNDEF_UniformMatrix2fv) || defined (GL_ALT_FUNDEF_ProgramUniformMatrix2fv)
@@ -419,33 +522,31 @@ GL_HPP_PROGRAM_UNIFORM_MATRIX_DEFINITION(GLfloat,3,3,UniformMatrix3fv);
 GL_HPP_PROGRAM_UNIFORM_MATRIX_DEFINITION(GLfloat,4,4,UniformMatrix4fv);
 #endif
     
-#if defined (GL_ALT_FUNDEF_UniformMatrix2x3fv) || defined (GL_ALT_FUNDEF_ProgramUniformMatrix2x3fv)
+///\todo the DSA version will not be available here if the regular version is not; no ARB or EXT in GL 2, so 2.1 fails to compile.  this goes for next 5 definitions
+#if defined (GL_ALT_FUNDEF_UniformMatrix2x3fv)
 GL_HPP_PROGRAM_UNIFORM_MATRIX_DEFINITION(GLfloat,2,3,UniformMatrix2x3fv);
 #endif
     
-#if defined (GL_ALT_FUNDEF_UniformMatrix3x2fv) || defined (GL_ALT_FUNDEF_ProgramUniformMatrix3x2fv)
+#if defined (GL_ALT_FUNDEF_UniformMatrix3x2fv)
 GL_HPP_PROGRAM_UNIFORM_MATRIX_DEFINITION(GLfloat,3,2,UniformMatrix3x2fv);
 #endif
     
-#if defined (GL_ALT_FUNDEF_UniformMatrix2x4fv) || defined (GL_ALT_FUNDEF_ProgramUniformMatrix2x4fv)
+#if defined (GL_ALT_FUNDEF_UniformMatrix2x4fv)
     GL_HPP_PROGRAM_UNIFORM_MATRIX_DEFINITION(GLfloat,2,4,UniformMatrix2x4fv);
 #endif
     
-#if defined (GL_ALT_FUNDEF_UniformMatrix4x2fv) || defined (GL_ALT_FUNDEF_ProgramUniformMatrix4x2fv)
-GL_HPP_PROGRAM_UNIFORM_MATRIX_DEFINITION(GLfloat,4,2,UniformMatrix4x2fv);
+#if defined (GL_ALT_FUNDEF_UniformMatrix4x2fv)
+    GL_HPP_PROGRAM_UNIFORM_MATRIX_DEFINITION(GLfloat,4,2,UniformMatrix4x2fv);
 #endif
     
-#if defined (GL_ALT_FUNDEF_UniformMatrix3x4fv) || defined (GL_ALT_FUNDEF_ProgramUniformMatrix3x4fv)
-GL_HPP_PROGRAM_UNIFORM_MATRIX_DEFINITION(GLfloat,3,4,UniformMatrix3x4fv);
+#if defined (GL_ALT_FUNDEF_UniformMatrix3x4fv)
+    GL_HPP_PROGRAM_UNIFORM_MATRIX_DEFINITION(GLfloat,3,4,UniformMatrix3x4fv);
 #endif
     
-#if defined (GL_ALT_FUNDEF_UniformMatrix4x3fv) || defined (GL_ALT_FUNDEF_ProgramUniformMatrix4x3fv)
-GL_HPP_PROGRAM_UNIFORM_MATRIX_DEFINITION(GLfloat,4,3,UniformMatrix4x3fv);
+#if defined (GL_ALT_FUNDEF_UniformMatrix4x3fv) 
+    GL_HPP_PROGRAM_UNIFORM_MATRIX_DEFINITION(GLfloat,4,3,UniformMatrix4x3fv);
 #endif
     
-#else
-
-#endif
 
 inline Program::ActiveInfo Program::GetActiveAttrib(GLuint index) const
 {
@@ -593,19 +694,24 @@ inline void Program::Use() const
 }
 #endif
 
+    
+#ifdef  GL_ALT_FUNDEF_BindFragDataLocation
 inline void Program::BindFragDataLocation(GLuint colorNumber,const std::string& name)
 {
 	glBindFragDataLocation(object,colorNumber,name.c_str());
 	_impl::_checkError(GL_INVALID_VALUE,"Binding Fragment Output Location failed: colorNumber is greater than or equal to GL_MAX_DRAW_BUFFERS");
 	_impl::_checkError(GL_INVALID_OPERATION,"Binding Fragment Output Location failed: name starts with the reserved gl_ prefix");
 }
+#endif
+    
+#ifdef GL_ALT_FUNDEF_GetFragDataLocation
 inline GLint Program::GetFragDataLocation(const std::string& name)
 {
 	return glGetFragDataLocation(object,name.c_str());
 }
+#endif
 
 #endif //GL_ALT_FUNDEF_CreateProgram
-
 
 //////////////////////////////////////////////////////////////////////////////////////
 //Buffer
@@ -648,17 +754,26 @@ inline void Buffer::FlushMappedRange(GLintptr offset,GLsizeiptr sz) const
 	else
     #endif
 	{
-		GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
+        
+        #if defined(GL_PIXEL_PACK_BUFFER)
+        const GLenum targetBinding = GL_PIXEL_PACK_BUFFER_BINDING;
+        const GLenum bufferTarget = GL_PIXEL_PACK_BUFFER;
+        #else
+        const GLenum targetBinding = GL_ARRAY_BUFFER_BINDING;
+        const GLenum bufferTarget = GL_ARRAY_BUFFER;
+        #endif
+        
+		GLint ppb_binding=gl::Get<GLint>(targetBinding);
 		if(ppb_binding!=object)
 		{
-			glBindBuffer(GL_PIXEL_PACK_BUFFER,object);
+			glBindBuffer(bufferTarget,object);
 		}
-		glFlushMappedBufferRange(GL_PIXEL_PACK_BUFFER,offset,sz);
+		glFlushMappedBufferRange(bufferTarget,offset,sz);
 		_impl::_checkError(GL_INVALID_VALUE,"Offset or length is negative, or offset + length exceeds the size of the mapping.");
 		_impl::_checkError(GL_INVALID_OPERATION,"Zero Buffer is bound to target, or the buffer bound to target is not mapped, or is mapped without the GL_MAP_FLUSH_EXPLICIT flag.");
 		if(ppb_binding!=object)
 		{
-			glBindBuffer(GL_PIXEL_PACK_BUFFER,ppb_binding);
+			glBindBuffer(bufferTarget,ppb_binding);
 		}
 	}
 }
@@ -681,26 +796,25 @@ inline void Buffer::GetSubData(GLintptr offset,GLsizeiptr size,void* output_buff
     {
         
         #if defined(GL_PIXEL_PACK_BUFFER)
-        GLenum targetBinding = GL_PIXEL_PACK_BUFFER_BINDING;
-        GLenum bufferTarget = GL_PIXEL_PACK_BUFFER;
+        const GLenum targetBinding = GL_PIXEL_PACK_BUFFER_BINDING;
+        const GLenum bufferTarget = GL_PIXEL_PACK_BUFFER;
         #else
-        GLenum targetBinding = GL_ELEMENT_ARRAY_BUFFER_BINDING;
-        GLenum bufferTarget = GL_ELEMENT_ARRAY_BUFFER;
+        const GLenum targetBinding = GL_ARRAY_BUFFER_BINDING;
+        const GLenum bufferTarget = GL_ARRAY_BUFFER;
         #endif
         
-        //chris
-		GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
+		GLint ppb_binding=gl::Get<GLint>(targetBinding);
 		if(ppb_binding!=object)
 		{
-			glBindBuffer(GL_PIXEL_PACK_BUFFER,object);
+			glBindBuffer(bufferTarget,object);
 		}
-		glGetBufferSubData(GL_PIXEL_PACK_BUFFER,offset,size,output_buffer);
+		glGetBufferSubData(bufferTarget,offset,size,output_buffer);
 		_impl::_checkError(GL_INVALID_ENUM,"Target is not GL_ARRAY_BUFFER, GL_ELEMENT_ARRAY_BUFFER, GL_PIXEL_PACK_BUFFER, or GL_PIXEL_UNPACK_BUFFER.");
 		_impl::_checkError(GL_INVALID_VALUE,"Offset or size is negative, or if together they define a region of memory that extends beyond the buffer object's allocated data store.");
 		_impl::_checkError(GL_INVALID_OPERATION,"The reserved buffer object name 0 is bound to target. OR The buffer object being queried is already mapped.");
 		if(ppb_binding!=object)
 		{
-			glBindBuffer(GL_PIXEL_PACK_BUFFER,ppb_binding);
+			glBindBuffer(bufferTarget,ppb_binding);
 		}
 	}
 }
@@ -720,17 +834,26 @@ inline void* Buffer::GetMappedPointer() const
 	else
     #endif
     {
-		GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
+        
+        #if defined(GL_PIXEL_PACK_BUFFER)
+        const GLenum targetBinding = GL_PIXEL_PACK_BUFFER_BINDING;
+        const GLenum bufferTarget = GL_PIXEL_PACK_BUFFER;
+        #else
+        const GLenum targetBinding = GL_ARRAY_BUFFER_BINDING;
+        const GLenum bufferTarget = GL_ARRAY_BUFFER;
+        #endif
+        
+		GLint ppb_binding=gl::Get<GLint>(targetBinding);
 		if(ppb_binding!=object)
 		{
-			glBindBuffer(GL_PIXEL_PACK_BUFFER,object);
+			glBindBuffer(bufferTarget,object);
 		}
-		glGetBufferPointerv(GL_PIXEL_PACK_BUFFER, GL_BUFFER_MAP_POINTER,&p);
+		glGetBufferPointerv(bufferTarget, GL_BUFFER_MAP_POINTER,&p);
 		_impl::_checkError(GL_INVALID_ENUM,"Target or pname is not an accepted value.");
 		_impl::_checkError(GL_INVALID_OPERATION,"The reserved buffer object name 0 is bound to target.");
 		if(ppb_binding!=object)
 		{
-			glBindBuffer(GL_PIXEL_PACK_BUFFER,ppb_binding);
+			glBindBuffer(bufferTarget,ppb_binding);
 		}
 	}
 	return p;
@@ -751,17 +874,26 @@ inline GLint Buffer::Get(GLenum value) const
 	else
     #endif
 	{
-		GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
+        
+        #if defined(GL_PIXEL_PACK_BUFFER)
+        const GLenum targetBinding = GL_PIXEL_PACK_BUFFER_BINDING;
+        const GLenum bufferTarget = GL_PIXEL_PACK_BUFFER;
+        #else
+        const GLenum targetBinding = GL_ARRAY_BUFFER_BINDING;
+        const GLenum bufferTarget = GL_ARRAY_BUFFER;
+        #endif
+        
+		GLint ppb_binding=gl::Get<GLint>(targetBinding);
 		if(ppb_binding!=object)
 		{
-			glBindBuffer(GL_PIXEL_PACK_BUFFER,object);
+			glBindBuffer(bufferTarget,object);
 		}
-		glGetBufferParameteriv(GL_PIXEL_PACK_BUFFER,value,&p);
+		glGetBufferParameteriv(bufferTarget,value,&p);
 		_impl::_checkError(GL_INVALID_ENUM,"target or value is not an accepted value");
 		_impl::_checkError(GL_INVALID_OPERATION,"Reserved buffer object name 0 is bound to target.");
 		if(ppb_binding!=object)
 		{
-			glBindBuffer(GL_PIXEL_PACK_BUFFER,ppb_binding);
+			glBindBuffer(bufferTarget,ppb_binding);
 		}
 	}
 	return p;
@@ -784,19 +916,28 @@ inline void Buffer::Data(GLsizeiptr sz,const GLvoid* data,GLenum usage)
 	else
     #endif
 	{
-		GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
+        
+        #if defined(GL_PIXEL_PACK_BUFFER)
+        const GLenum targetBinding = GL_PIXEL_PACK_BUFFER_BINDING;
+        const GLenum bufferTarget = GL_PIXEL_PACK_BUFFER;
+        #else
+        const GLenum targetBinding = GL_ARRAY_BUFFER_BINDING;
+        const GLenum bufferTarget = GL_ARRAY_BUFFER;
+        #endif
+        
+		GLint ppb_binding=gl::Get<GLint>(targetBinding);
 		if(ppb_binding!=object)
 		{
-			glBindBuffer(GL_PIXEL_PACK_BUFFER,object);
+			glBindBuffer(bufferTarget,object);
 		}
-		glBufferData(GL_PIXEL_PACK_BUFFER,sz,data,usage);
+		glBufferData(bufferTarget,sz,data,usage);
 		_impl::_checkError(GL_INVALID_ENUM,"target is not one of the accepted buffer targets OR usage is not GL_STREAM_DRAW, GL_STREAM_READ, GL_STREAM_COPY, GL_STATIC_DRAW, GL_STATIC_READ, GL_STATIC_COPY, GL_DYNAMIC_DRAW, GL_DYNAMIC_READ, or GL_DYNAMIC_COPY.");
 		_impl::_checkError(GL_INVALID_VALUE,"size is negative.");
 		_impl::_checkError(GL_INVALID_OPERATION,"Cannot bind the reserved buffer name 0 to anything.");
 		_impl::_checkError(GL_OUT_OF_MEMORY,"The GL is unable to create a data store with the specified size.");
 		if(ppb_binding!=object)
 		{
-			glBindBuffer(GL_PIXEL_PACK_BUFFER,ppb_binding);
+			glBindBuffer(bufferTarget,ppb_binding);
 		}
 	}
 }
@@ -824,17 +965,26 @@ inline void Buffer::SubData(GLintptr offset,GLsizeiptr size,const GLvoid* data)
 	else
     #endif
 	{
-		GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
+        
+        #if defined(GL_PIXEL_PACK_BUFFER)
+        const GLenum targetBinding = GL_PIXEL_PACK_BUFFER_BINDING;
+        const GLenum bufferTarget = GL_PIXEL_PACK_BUFFER;
+        #else
+        const GLenum targetBinding = GL_ARRAY_BUFFER_BINDING;
+        const GLenum bufferTarget = GL_ARRAY_BUFFER;
+        #endif
+        
+		GLint ppb_binding=gl::Get<GLint>(targetBinding);
 		if(ppb_binding!=object)
 		{
-			glBindBuffer(GL_PIXEL_PACK_BUFFER,object);
+			glBindBuffer(bufferTarget,object);
 		}
-		glBufferSubData(GL_PIXEL_PACK_BUFFER,offset,size,data);
+		glBufferSubData(bufferTarget,offset,size,data);
 		_impl::_checkError(GL_INVALID_VALUE,"Offset or size is negative, or together they define a region of memory that extends beyond the buffer object's allocated data store.");
 		_impl::_checkError(GL_INVALID_OPERATION,"The buffer object being updated is currently mapped, or the reserved buffer object name 0 is bound to target.");
 		if(ppb_binding!=object)
 		{
-			glBindBuffer(GL_PIXEL_PACK_BUFFER,ppb_binding);
+			glBindBuffer(bufferTarget,ppb_binding);
 		}
 	}
 }
@@ -850,19 +1000,28 @@ inline void Buffer::SubData(GLintptr offset,const T* b,const T* e)
 #ifdef GL_ALT_FUNDEF_ClearBufferData
 inline void Buffer::ClearData(GLenum internalformat,GLenum format,GLenum type,const void* data)
 {
-	GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
+    
+    #if defined(GL_PIXEL_PACK_BUFFER)
+    const GLenum targetBinding = GL_PIXEL_PACK_BUFFER_BINDING;
+    const GLenum bufferTarget = GL_PIXEL_PACK_BUFFER;
+    #else
+    const GLenum targetBinding = GL_ARRAY_BUFFER_BINDING;
+    const GLenum bufferTarget = GL_ARRAY_BUFFER;
+    #endif
+    
+	GLint ppb_binding=gl::Get<GLint>(targetBinding);
 	if(ppb_binding!=object)
 	{
-		glBindBuffer(GL_PIXEL_PACK_BUFFER,object);
+		glBindBuffer(bufferTarget,object);
 	}
-	glClearBufferData(GL_PIXEL_PACK_BUFFER_BINDING,internalformat,format,type,data);
+	glClearBufferData(targetBinding,internalformat,format,type,data);
 			
 	_impl::_checkError(GL_INVALID_ENUM,"internalformat is not a sized internal format.");
 	_impl::_checkError(GL_INVALID_OPERATION,"Part of the buffer's data stor,e is mapped with glMapBufferRange or glMapBuffer.");
 	
 	if(ppb_binding!=object)
 	{
-		glBindBuffer(GL_PIXEL_PACK_BUFFER,ppb_binding);
+		glBindBuffer(bufferTarget,ppb_binding);
 	}
 }
 #endif
@@ -870,12 +1029,21 @@ inline void Buffer::ClearData(GLenum internalformat,GLenum format,GLenum type,co
 #ifdef GL_ALT_FUNDEF_ClearBufferSubData
 inline void Buffer::ClearSubData(GLenum internalformat,GLintptr offset,GLsizeiptr size,GLenum format,GLenum type,const void* data)
 {
-	GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
+    
+#if defined(GL_PIXEL_PACK_BUFFER)
+    const GLenum targetBinding = GL_PIXEL_PACK_BUFFER_BINDING;
+    const GLenum bufferTarget = GL_PIXEL_PACK_BUFFER;
+#else
+    const GLenum targetBinding = GL_ARRAY_BUFFER_BINDING;
+    const GLenum bufferTarget = GL_ARRAY_BUFFER;
+#endif
+    
+	GLint ppb_binding=gl::Get<GLint>(targetBinding);
 	if(ppb_binding!=object)
 	{
-		glBindBuffer(GL_PIXEL_PACK_BUFFER,object);
+		glBindBuffer(bufferTarget,object);
 	}
-	glClearBufferSubData(GL_PIXEL_PACK_BUFFER_BINDING,internalformat,offset,size,format,type,data);
+	glClearBufferSubData(targetBinding,internalformat,offset,size,format,type,data);
 	
 	_impl::_checkError(GL_INVALID_ENUM,"Target not one of the generic buffer binding targets, or internalformat is not a sized internal format.");
 	_impl::_checkError(GL_INVALID_VALUE,"No buffer is bound to GL_PIXEL_PACK_BUFFER_BINDING. OR offset or range are not multiples of the number of basic machine units per-element for the internal format specified by internalformat. OR  offset or size is less than zero, or if offset + size is greater than the value of GL_BUFFER_SIZE for the buffer bound to target.");
@@ -883,7 +1051,7 @@ inline void Buffer::ClearSubData(GLenum internalformat,GLintptr offset,GLsizeipt
 	
 	if(ppb_binding!=object)
 	{
-		glBindBuffer(GL_PIXEL_PACK_BUFFER,ppb_binding);
+		glBindBuffer(bufferTarget,ppb_binding);
 	}
 }
 #endif
@@ -910,11 +1078,20 @@ inline void Buffer::InvalidateSubData(GLintptr offset,GLsizeiptr length)
 #if defined(GL_ALT_FUNDEF_MapBuffer) || defined(GL_ALT_FUNDEF_MapNamedBufferEXT)
 inline void* Buffer::Map(GLenum access)
 {
+    
+#if defined(GL_PIXEL_PACK_BUFFER)
+    const GLenum targetBinding = GL_PIXEL_PACK_BUFFER_BINDING;
+    const GLenum bufferTarget = GL_PIXEL_PACK_BUFFER;
+#else
+    const GLenum targetBinding = GL_ARRAY_BUFFER_BINDING;
+    const GLenum bufferTarget = GL_ARRAY_BUFFER;
+#endif
+    
 	void *p;
     #ifdef GL_EXT_direct_state_access
 	if(direct_state_access_supported)
 	{
-		p=glMapNamedBufferEXT(GL_PIXEL_PACK_BUFFER_BINDING,access);
+		p=glMapNamedBufferEXT(targetBinding,access);
 		_impl::_checkError(GL_INVALID_ENUM,"Access flag is incorrect is not GL_READ_ONLY, GL_WRITE_ONLY, or GL_READ_WRITE.");
 		_impl::_checkError(GL_OUT_OF_MEMORY,"The GL is unable to map the buffer object's data store. This may occur for a variety of system-specific reasons, such as the absence of sufficient remaining virtual memory.");
 		_impl::_checkError(GL_INVALID_OPERATION,"Cannot remap a buffer object whose data store is already mapped.");
@@ -922,18 +1099,18 @@ inline void* Buffer::Map(GLenum access)
 	else
     #endif
 	{
-		GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
+		GLint ppb_binding=gl::Get<GLint>(targetBinding);
 		if(ppb_binding!=object)
 		{
-			glBindBuffer(GL_PIXEL_PACK_BUFFER,object);
+			glBindBuffer(bufferTarget,object);
 		}
-		p=glMapBuffer(GL_PIXEL_PACK_BUFFER_BINDING,access);
+		p=glMapBuffer(bufferTarget,access);
 		_impl::_checkError(GL_INVALID_ENUM,"Access flag is incorrect is not GL_READ_ONLY, GL_WRITE_ONLY, or GL_READ_WRITE.");
 		_impl::_checkError(GL_OUT_OF_MEMORY,"The GL is unable to map the buffer object's data store. This may occur for a variety of system-specific reasons, such as the absence of sufficient remaining virtual memory.");
 		_impl::_checkError(GL_INVALID_OPERATION,"Cannot remap a buffer object whose data store is already mapped.");
 		if(ppb_binding!=object)
 		{
-			glBindBuffer(GL_PIXEL_PACK_BUFFER,ppb_binding);
+			glBindBuffer(bufferTarget,ppb_binding);
 		}
 	}
 	return p;
@@ -961,17 +1138,26 @@ inline bool Buffer::Unmap()
 	else
     #endif
     {
-		GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
+        
+        #if defined(GL_PIXEL_PACK_BUFFER)
+        const GLenum targetBinding = GL_PIXEL_PACK_BUFFER_BINDING;
+        const GLenum bufferTarget = GL_PIXEL_PACK_BUFFER;
+        #else
+        const GLenum targetBinding = GL_ARRAY_BUFFER_BINDING;
+        const GLenum bufferTarget = GL_ARRAY_BUFFER;
+        #endif
+        
+		GLint ppb_binding=gl::Get<GLint>(targetBinding);
 		if(ppb_binding!=object)
 		{
-			glBindBuffer(GL_PIXEL_PACK_BUFFER,object);
+			glBindBuffer(bufferTarget,object);
 		}
 
-		p=glUnmapBuffer(GL_PIXEL_PACK_BUFFER) == GL_TRUE;
+		p=glUnmapBuffer(bufferTarget) == GL_TRUE;
 		_impl::_checkError(GL_INVALID_OPERATION,"Cannot unmap a buffer object whose data store is not mapped.");
 		if(ppb_binding!=object)
 		{
-			glBindBuffer(GL_PIXEL_PACK_BUFFER,ppb_binding);
+			glBindBuffer(bufferTarget,ppb_binding);
 		}
 	}
 	return p;
@@ -981,6 +1167,15 @@ inline bool Buffer::Unmap()
 #if defined(GL_ALT_FUNDEF_MapBufferRange) || defined(GL_ALT_FUNDEF_MapNamedBufferRangeEXT)
 inline void* Buffer::MapRange(GLintptr offset,GLsizeiptr length,GLbitfield access)
 {
+    
+#if defined(GL_PIXEL_PACK_BUFFER)
+    const GLenum targetBinding = GL_PIXEL_PACK_BUFFER_BINDING;
+    const GLenum bufferTarget = GL_PIXEL_PACK_BUFFER;
+#else
+    const GLenum targetBinding = GL_ARRAY_BUFFER_BINDING;
+    const GLenum bufferTarget = GL_ARRAY_BUFFER;
+#endif
+    
 	void *p;
     #ifdef GL_EXT_direct_state_access
 	if(direct_state_access_supported)
@@ -993,18 +1188,18 @@ inline void* Buffer::MapRange(GLintptr offset,GLsizeiptr length,GLbitfield acces
 	else
     #endif
 	{
-		GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
+		GLint ppb_binding=gl::Get<GLint>(targetBinding);
 		if(ppb_binding!=object)
 		{
-			glBindBuffer(GL_PIXEL_PACK_BUFFER,object);
+			glBindBuffer(bufferTarget,object);
 		}
-		p=glMapBufferRange(GL_PIXEL_PACK_BUFFER_BINDING,offset,length,access);
+		p=glMapBufferRange(targetBinding,offset,length,access);
 		_impl::_checkError(GL_INVALID_ENUM,"Access flag is incorrect is not GL_READ_ONLY, GL_WRITE_ONLY, or GL_READ_WRITE.");
 		_impl::_checkError(GL_OUT_OF_MEMORY,"The GL is unable to map the buffer object's data store. This may occur for a variety of system-specific reasons, such as the absence of sufficient remaining virtual memory.");
 		_impl::_checkError(GL_INVALID_OPERATION,"Cannot remap a buffer object whose data store is already mapped.");
 		if(ppb_binding!=object)
 		{
-			glBindBuffer(GL_PIXEL_PACK_BUFFER,ppb_binding);
+			glBindBuffer(bufferTarget,ppb_binding);
 		}
 	}
 	return p;
@@ -1079,8 +1274,15 @@ inline void VertexArray::EnableAttrib(GLuint index)
 		{
 			glBindVertexArray(object);
 		}
+        
+        #if defined(GL_ALT_FUNDEF_EnableVertexAttribArray)
 		glEnableVertexAttribArray(index);
-		_impl::_checkError(GL_INVALID_VALUE,"Index is greater than or equal to GL_MAX_VERTEX_ATTRIBS.");
+        #elif defined(GL_ALT_FUNDEF_EnableVertexAttribArrayARB)
+        glEnableVertexAttribArrayARB(index);
+        #else
+        #error no declaration of glEnableVertexAttribArray found
+        #endif
+        _impl::_checkError(GL_INVALID_VALUE,"Index is greater than or equal to GL_MAX_VERTEX_ATTRIBS.");
 		if(pbinding!=object)
 		{
 			glBindVertexArray(pbinding);
@@ -1106,7 +1308,15 @@ inline void VertexArray::DisableAttrib(GLuint index)
 		{
 			glBindVertexArray(object);
 		}
+        
+        #if defined(GL_ALT_FUNDEF_DisableVertexAttribArray)
 		glDisableVertexAttribArray(index);
+        #elif defined(GL_ALT_FUNDEF_DisableVertexAttribArrayARB)
+        glDisableVertexAttribArrayARB(index);
+        #else
+        #error no declaration of glDisableVertexAttribArray found
+        #endif
+        
 		_impl::_checkError(GL_INVALID_VALUE,"Index is greater than or equal to GL_MAX_VERTEX_ATTRIBS.");
 		if(pbinding!=object)
 		{
@@ -1139,8 +1349,16 @@ inline void VertexArray::AttribPointer(GLuint index,GLint size,GLenum type,bool 
 		{
 			glBindVertexArray(object);
 		}
+        
+        #if defined(GL_ALT_FUNDEF_VertexAttribPointer)
 		glVertexAttribPointer(index,size,type,normalized ? GL_TRUE : GL_FALSE,stride,pointer);
-		_impl::_checkError(GL_INVALID_VALUE,"Attribute index is greater than or equal to GL_MAX_VERTEX_ATTRIBS. OR Size is not 1, 2, 3, 4 or (for glVertexAttribPointer), GL_BGRA. OR Stride is negative.");
+        #elif defined(GL_ALT_FUNDEF_VertexAttribPointerARB)
+        glVertexAttribPointerARB(index,size,type,normalized ? GL_TRUE : GL_FALSE,stride,pointer);
+        #else 
+        #error no declaration of glVertexAttribPointer found
+        #endif
+        
+        _impl::_checkError(GL_INVALID_VALUE,"Attribute index is greater than or equal to GL_MAX_VERTEX_ATTRIBS. OR Size is not 1, 2, 3, 4 or (for glVertexAttribPointer), GL_BGRA. OR Stride is negative.");
 		_impl::_checkError(GL_INVALID_ENUM,"Type is not an accepted value.");
 		_impl::_checkError(GL_INVALID_OPERATION,"Size is GL_BGRA and type is not GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV. OR type is GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV and size is not 4 or GL_BGRA. OR size is GL_BGRA and noramlized is GL_FALSE. OR zero is bound to the GL_ARRAY_BUFFER buffer object binding point and the pointer argument is not NULL.");
 		if(pbinding!=object)
@@ -1149,7 +1367,9 @@ inline void VertexArray::AttribPointer(GLuint index,GLint size,GLenum type,bool 
 		}
 	}
 }
-    
+
+#if defined(GL_ALT_FUNDEF_GenBuffers)
+#if defined(GL_ALT_FUNDEF_VertexArrayVertexAttribOffsetEXT) || defined(GL_ALT_FUNDEF_VertexAttribPointer)
 inline void VertexArray::AttribPointer(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const Buffer& b,GLsizeiptr offset)
 {
     #ifdef GL_EXT_direct_state_access
@@ -1175,6 +1395,8 @@ inline void VertexArray::AttribPointer(GLuint index,GLint size,GLenum type,bool 
         }
     }
 }
+#endif
+#endif
     
 inline void VertexArray::Attrib(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const GLvoid * pointer)
 {
@@ -1182,14 +1404,16 @@ inline void VertexArray::Attrib(GLuint index,GLint size,GLenum type,bool normali
     EnableAttrib(index);
 }
     
+#if defined(GL_ALT_FUNDEF_GenBuffers)
 inline void VertexArray::Attrib(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const Buffer& b,GLsizeiptr offset)
 {
     AttribPointer(index,size,type,normalized,stride,b,offset);        EnableAttrib(index);
 }
+#endif
     
 #endif
     
-#if defined(GL_ALT_FUNDEF_VertexArrayVertexAttribIOffsetEXT) || defined(GL_ALT_FUNDEF_VertexAttribIPointer)
+#if defined(GL_ALT_FUNDEF_VertexArrayVertexAttribIOffsetEXT) || defined(GL_ALT_FUNDEF_VertexAttribIPointer) || defined(GL_ALT_FUNDEF_VertexAttribIPointerEXT)
 inline void VertexArray::AttribIPointer(GLuint index,GLint size,GLenum type,GLsizei stride,const GLvoid * pointer)
 {
     #ifdef GL_EXT_direct_state_access
@@ -1208,8 +1432,17 @@ inline void VertexArray::AttribIPointer(GLuint index,GLint size,GLenum type,GLsi
 		{
 			glBindVertexArray(object);
 		}
-		glVertexAttribIPointer(index,size,type,stride,pointer);
-		_impl::_checkError(GL_INVALID_VALUE,"Attribute index is greater than or equal to GL_MAX_VERTEX_ATTRIBS. OR Size is not 1, 2, 3, 4 or (for glVertexAttribPointer), GL_BGRA. OR Stride is negative.");
+		
+        #if defined(GL_ALT_FUNDEF_VertexAttribIPointer)
+        glVertexAttribIPointer(index,size,type,stride,pointer);
+        #elif defined(GL_ALT_FUNDEF_VertexAttribIPointerEXT)
+        glVertexAttribIPointerEXT(index,size,type,stride,pointer);
+        #else
+        #error no declaration for VertexAttribIPointer found
+        #endif
+
+        
+        _impl::_checkError(GL_INVALID_VALUE,"Attribute index is greater than or equal to GL_MAX_VERTEX_ATTRIBS. OR Size is not 1, 2, 3, 4 or (for glVertexAttribPointer), GL_BGRA. OR Stride is negative.");
 		_impl::_checkError(GL_INVALID_ENUM,"Type is not an accepted value.");
 		_impl::_checkError(GL_INVALID_OPERATION,"Size is GL_BGRA and type is not GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV. OR type is GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV and size is not 4 or GL_BGRA. OR size is GL_BGRA and noramlized is GL_FALSE. OR zero is bound to the GL_ARRAY_BUFFER buffer object binding point and the pointer argument is not NULL.");
 		if(pbinding!=object)
@@ -1220,6 +1453,7 @@ inline void VertexArray::AttribIPointer(GLuint index,GLint size,GLenum type,GLsi
 }
 
 
+#if defined(GL_ALT_FUNDEF_GenBuffers)
 inline void VertexArray::AttribIPointer(GLuint index,GLint size,GLenum type,GLsizei stride,const Buffer& b,GLsizeiptr offset)
 {
     #ifdef GL_EXT_direct_state_access
@@ -1245,6 +1479,7 @@ inline void VertexArray::AttribIPointer(GLuint index,GLint size,GLenum type,GLsi
 		}
 	}
 }
+#endif
     
 inline void VertexArray::AttribI(GLuint index,GLint size,GLenum type,GLsizei stride,const GLvoid * pointer)
 {
@@ -1252,11 +1487,14 @@ inline void VertexArray::AttribI(GLuint index,GLint size,GLenum type,GLsizei str
 	EnableAttrib(index);
 }
 
+    
+#if defined(GL_ALT_FUNDEF_GenBuffers)
 inline void VertexArray::AttribI(GLuint index,GLint size,GLenum type,GLsizei stride,const Buffer& b,GLsizeiptr offset)
 {
 	AttribIPointer(index,size,type,stride,b,offset);
 	EnableAttrib(index);
 }
+#endif
 #endif
 
 #if defined(GL_ALT_FUNDEF_BindVertexArray) && defined(GL_ALT_FUNDEF_BindBuffer)
@@ -1409,10 +1647,16 @@ inline GLuint64 Query::Get<GLuint64>(GLenum pname) const
 inline ContextInfo::ContextInfo():
 		vendor(Get<std::string>(GL_VENDOR)),
 		renderer(Get<std::string>(GL_RENDERER)),
-		version(Get<std::string>(GL_VERSION)),
-		glsl_version(Get<std::string>(GL_SHADING_LANGUAGE_VERSION))
+		version(Get<std::string>(GL_VERSION))
+		
+        #if defined(GL_SHADING_LANGUAGE_VERSION)
+        ,glsl_version(Get<std::string>(GL_SHADING_LANGUAGE_VERSION))
+        #else
+        ,glsl_version("")
+        #endif
+    
         #if defined(GL_NUM_EXTENSIONS)
-        ,gl_extensions(Get<GLint>(GL_NUM_EXTENSIONS)),
+        ,gl_extensions(Get<GLint>(GL_NUM_EXTENSIONS))
         #endif
         #if defined(GL_MAJOR_VERSION) && defined(GL_MINOR_VERSION)
         ,versionmajor(Get<GLint>(GL_MAJOR_VERSION)),
@@ -1560,6 +1804,7 @@ inline void Texture::texture_function_dsaf(Callable1 dsafunc,Callable2 ndsafunc,
 }
 #endif
 
+#if defined(GL_ALT_FUNDEF_BindMultiTextureEXT) && defined(GL_ALT_FUNDEF_ActiveTexture)
 inline void Texture::BindMulti(GLuint unit,GLenum targ)
 {
 	GLenum tu = targ ? targ : m_target;
@@ -1578,7 +1823,10 @@ inline void Texture::BindMulti(GLuint unit,GLenum targ)
 		glActiveTexture(at);
 	}
 }
+#endif
 
+
+#if defined(GL_ALT_FUNDEF_GenTextures)
 #if defined(GL_ALT_FUNDEF_GetTextureParameterivEXT) || defined(GL_ALT_FUNDEF_GetTexParameteriv)
 template<>
 inline GLint Texture::GetParameter<GLint>(GLenum targ,GLenum pname)
@@ -1615,38 +1863,56 @@ inline GLfloat Texture::GetParameter<GLfloat>(GLenum pname)
 	return out[0];
 }
 #endif
+
+
+#if defined(GL_ALT_FUNDEF_GetTextureParameterIivEXT) || defined(GL_ALT_FUNDEF_GetTexParameterIiv) || defined(GL_ALT_FUNDEF_GetTexParameterIivEXT)
     
-    
-#if defined(GL_ALT_FUNDEF_GetTextureParameterIivEXT) || defined(GL_ALT_FUNDEF_GetTexParameterIiv)
+#if defined(GL_ALT_FUNDEF_GetTexParameterIiv)
+#define GL_ALT_TexParameterIivFunc glGetTexParameterIiv
+#elif defined(GL_ALT_FUNDEF_GetTexParameterIivEXT)
+#define GL_ALT_TexParameterIivFunc glGetTexParameterIivEXT
+#else
+#error No declaration of texParameterIiv found ///\todo overload the dsa funcs to allow dsa only mode
+#endif
+
 template<>
 inline GLint Texture::GetParameterI<GLint>(GLenum targ,GLenum pname)
 {
 	GLint out[4];
-	texture_function_dsa(&glGetTextureParameterIivEXT,&glGetTexParameterIiv,targ,pname,out);
+	texture_function_dsa(&glGetTextureParameterIivEXT,&GL_ALT_TexParameterIivFunc,targ,pname,out);
 	return out[0];
 }
 template<>
 inline GLint Texture::GetParameterI<GLint>(GLenum pname)
 {
 	GLint out[4];
-	texture_function_dsa(&glGetTextureParameterIivEXT,&glGetTexParameterIiv,m_target,pname,out);
+	texture_function_dsa(&glGetTextureParameterIivEXT,&GL_ALT_TexParameterIivFunc,m_target,pname,out);
 	return out[0];
 }
 #endif
     
-#if defined(GL_ALT_FUNDEF_GetTextureParameterIuivEXT) || defined(GL_ALT_FUNDEF_GetTexParameterIuiv)
+#if defined(GL_ALT_FUNDEF_GetTextureParameterIuivEXT) || defined(GL_ALT_FUNDEF_GetTexParameterIuiv) || defined(GL_ALT_FUNDEF_GetTexParameterIuivEXT)
+    
+#if defined(GL_ALT_FUNDEF_GetTexParameterIuiv)
+#define GL_ALT_GetTexParameterIuivFUNC glGetTexParameterIuiv
+#elif defined(GL_ALT_FUNDEF_GetTexParameterIuivEXT)
+#define GL_ALT_GetTexParameterIuivFUNC glGetTexParameterIuivEXT
+#else
+#error No declaration of texParameterIuiv found ///\todo overload the dsa funcs to allow dsa only mode
+#endif
+    
 template<>
 inline GLuint Texture::GetParameterI<GLuint>(GLenum targ,GLenum pname)
 {
 	GLuint out[4];
-	texture_function_dsa(&glGetTextureParameterIuivEXT,&glGetTexParameterIuiv,targ,pname,out);
+	texture_function_dsa(&glGetTextureParameterIuivEXT,&GL_ALT_GetTexParameterIuivFUNC,targ,pname,out);
 	return out[0];
 }
 template<>
 inline GLuint Texture::GetParameterI<GLuint>(GLenum pname)
 {
 	GLuint out[4];
-	texture_function_dsa(&glGetTextureParameterIuivEXT,&glGetTexParameterIuiv,m_target,pname,out);
+	texture_function_dsa(&glGetTextureParameterIuivEXT,&GL_ALT_GetTexParameterIuivFUNC,m_target,pname,out);
 	return out[0];
 }
 #endif
@@ -1686,6 +1952,8 @@ inline GLfloat Texture::GetLevelParameter(int lod, GLenum value)
 #endif
 
 
+#endif //defined(GL_ALT_FUNDEF_GenTextures)
+    
 #ifdef GL_ALT_FUNDEF_GenFramebuffers
 template<class Callable1,class Callable2,typename... Types>
 inline void Framebuffer::framebuffer_function_dsaf(Callable1 dsafunc,Callable2 ndsafunc,Types... params)

--- a/opengl.inl
+++ b/opengl.inl
@@ -57,6 +57,8 @@ static inline void checkUniform()
 
 }
 }
+    
+    
 ///////////////////////////////////////////////////
 //GETTERS
 #ifdef GL_ALT_FUNDEF_GetFloatv
@@ -614,12 +616,16 @@ inline void Buffer::Bind(GLenum bt) const
 	_impl::_checkError(GL_INVALID_ENUM,"Cannot Bind Buffer: Buffer target is not one of the allowable values.");
 }
 
+#ifdef GL_ALT_FUNDEF_BindBufferRange
 inline void Buffer::BindRange(GLenum target, GLuint index,GLintptr offset, GLsizeiptr size) const
 {
 	glBindBufferRange(target,index,object,offset,size);
 	_impl::_checkError(GL_INVALID_ENUM,"Target is not GL_TRANSFORM_FEEDBACK_BUFFER or GL_UNIFORM_BUFFER.");
 	_impl::_checkError(GL_INVALID_VALUE,"Is generated if index is greater than or equal to the number of target-specific indexed binding points. OR size is less than or equal to zero, or if offset + size is greater than the value of GL_BUFFER_SIZE.");
 }
+#endif
+
+#ifdef GL_ALT_FUNDEF_BindBufferBase
 inline void Buffer::BindBase(GLenum target,GLuint index) const
 {
 	glBindBufferBase(target,index,object);
@@ -627,11 +633,12 @@ inline void Buffer::BindBase(GLenum target,GLuint index) const
 	_impl::_checkError(GL_INVALID_ENUM,"Target is not GL_TRANSFORM_FEEDBACK_BUFFER or GL_UNIFORM_BUFFER.");
 	_impl::_checkError(GL_INVALID_VALUE,"Is generated if index is greater than or equal to the number of target-specific indexed binding points. OR size is less than or equal to zero or it doesn't have a data store");
 }
-
+#endif
     
 #if defined(GL_ALT_FUNDEF_FlushMappedNamedBufferRangeEXT) || defined(GL_ALT_FUNDEF_FlushMappedBufferRange)
 inline void Buffer::FlushMappedRange(GLintptr offset,GLsizeiptr sz) const
 {
+    #ifdef GL_EXT_direct_state_access
 	if(direct_state_access_supported)
 	{
 		glFlushMappedNamedBufferRangeEXT(object,offset,sz);
@@ -639,6 +646,7 @@ inline void Buffer::FlushMappedRange(GLintptr offset,GLsizeiptr sz) const
 		_impl::_checkError(GL_INVALID_OPERATION,"Zero Buffer is bound to target, or the buffer bound to target is not mapped, or is mapped without the GL_MAP_FLUSH_EXPLICIT flag.");
 	}
 	else
+    #endif
 	{
 		GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
 		if(ppb_binding!=object)
@@ -656,8 +664,10 @@ inline void Buffer::FlushMappedRange(GLintptr offset,GLsizeiptr sz) const
 }
 #endif
 
+#if defined(GL_ALT_FUNDEF_GetNamedBufferSubDataEXT) || defined(GL_ALT_FUNDEF_GetBufferSubData)
 inline void Buffer::GetSubData(GLintptr offset,GLsizeiptr size,void* output_buffer) const
 {
+    #ifdef GL_EXT_direct_state_access
 	if(direct_state_access_supported)
 	{
 		glGetNamedBufferSubDataEXT(object,offset,size,output_buffer);
@@ -667,7 +677,18 @@ inline void Buffer::GetSubData(GLintptr offset,GLsizeiptr size,void* output_buff
 
 	}
 	else
-	{
+    #endif
+    {
+        
+        #if defined(GL_PIXEL_PACK_BUFFER)
+        GLenum targetBinding = GL_PIXEL_PACK_BUFFER_BINDING;
+        GLenum bufferTarget = GL_PIXEL_PACK_BUFFER;
+        #else
+        GLenum targetBinding = GL_ELEMENT_ARRAY_BUFFER_BINDING;
+        GLenum bufferTarget = GL_ELEMENT_ARRAY_BUFFER;
+        #endif
+        
+        //chris
 		GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
 		if(ppb_binding!=object)
 		{
@@ -683,9 +704,13 @@ inline void Buffer::GetSubData(GLintptr offset,GLsizeiptr size,void* output_buff
 		}
 	}
 }
+#endif
+    
+#if defined(GL_ALT_FUNDEF_GetNamedBufferPointervEXT) || defined(GL_ALT_FUNDEF_GetBufferPointerv)
 inline void* Buffer::GetMappedPointer() const
 {
 	void* p;
+    #ifdef GL_EXT_direct_state_access
 	if(direct_state_access_supported)
 	{
 		glGetNamedBufferPointervEXT(object, GL_BUFFER_MAP_POINTER,&p);
@@ -693,7 +718,8 @@ inline void* Buffer::GetMappedPointer() const
 		_impl::_checkError(GL_INVALID_OPERATION,"The reserved buffer object name 0 is bound to target.");
 	}
 	else
-	{
+    #endif
+    {
 		GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
 		if(ppb_binding!=object)
 		{
@@ -709,10 +735,13 @@ inline void* Buffer::GetMappedPointer() const
 	}
 	return p;
 }
-
+#endif
+    
+#if defined(GL_ALT_FUNDEF_GetNamedBufferParameterivEXT) || defined(GL_ALT_FUNDEF_GetBufferParameteriv)
 inline GLint Buffer::Get(GLenum value) const
 {
 	GLint p;
+    #ifdef GL_EXT_direct_state_access
 	if(direct_state_access_supported)
 	{
 		glGetNamedBufferParameterivEXT(object,value,&p);
@@ -720,6 +749,7 @@ inline GLint Buffer::Get(GLenum value) const
 		_impl::_checkError(GL_INVALID_OPERATION,"Reserved buffer object name 0 is bound to target.");
 	}
 	else
+    #endif
 	{
 		GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
 		if(ppb_binding!=object)
@@ -736,9 +766,13 @@ inline GLint Buffer::Get(GLenum value) const
 	}
 	return p;
 }
+#endif
 
+    
+#if defined(GL_ALT_FUNDEF_NamedBufferDataEXT) || defined(GL_ALT_FUNDEF_BindBuffer)
 inline void Buffer::Data(GLsizeiptr sz,const GLvoid* data,GLenum usage)
 {
+    #ifdef GL_EXT_direct_state_access
 	if(direct_state_access_supported)
 	{
 		glNamedBufferDataEXT(object,sz,data,usage);
@@ -748,6 +782,7 @@ inline void Buffer::Data(GLsizeiptr sz,const GLvoid* data,GLenum usage)
 		_impl::_checkError(GL_OUT_OF_MEMORY,"The GL is unable to create a data store with the specified size.");
 	}
 	else
+    #endif
 	{
 		GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
 		if(ppb_binding!=object)
@@ -766,15 +801,20 @@ inline void Buffer::Data(GLsizeiptr sz,const GLvoid* data,GLenum usage)
 	}
 }
 
+
 template<class T>
 inline void Buffer::Data(const T* b,const T* e,GLenum usage)
 {
 	GLsizeiptr sz=(e-b);
 	Data(sz*sizeof(T),reinterpret_cast<const GLvoid*>(b),usage);
 }
-
+    
+#endif
+    
+#if defined(GL_ALT_FUNDEF_NamedBufferSubDataEXT) || defined(GL_ALT_FUNDEF_BufferSubData)
 inline void Buffer::SubData(GLintptr offset,GLsizeiptr size,const GLvoid* data)
 {
+    #ifdef GL_EXT_direct_state_access
 	if(direct_state_access_supported)
 	{
 		glNamedBufferSubDataEXT(object,offset,size,data);
@@ -782,6 +822,7 @@ inline void Buffer::SubData(GLintptr offset,GLsizeiptr size,const GLvoid* data)
 		_impl::_checkError(GL_INVALID_OPERATION,"The buffer object being updated is currently mapped, or the reserved buffer object name 0 is bound to target.");
 	}
 	else
+    #endif
 	{
 		GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
 		if(ppb_binding!=object)
@@ -797,7 +838,16 @@ inline void Buffer::SubData(GLintptr offset,GLsizeiptr size,const GLvoid* data)
 		}
 	}
 }
-
+    
+template<class T>
+inline void Buffer::SubData(GLintptr offset,const T* b,const T* e)
+{
+    GLsizeiptr sz=(e-b);
+    SubData(offset*sizeof(T),sz*sizeof(T),reinterpret_cast<const GLvoid*>(b));
+}
+#endif
+    
+#ifdef GL_ALT_FUNDEF_ClearBufferData
 inline void Buffer::ClearData(GLenum internalformat,GLenum format,GLenum type,const void* data)
 {
 	GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
@@ -815,6 +865,9 @@ inline void Buffer::ClearData(GLenum internalformat,GLenum format,GLenum type,co
 		glBindBuffer(GL_PIXEL_PACK_BUFFER,ppb_binding);
 	}
 }
+#endif
+
+#ifdef GL_ALT_FUNDEF_ClearBufferSubData
 inline void Buffer::ClearSubData(GLenum internalformat,GLintptr offset,GLsizeiptr size,GLenum format,GLenum type,const void* data)
 {
 	GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
@@ -833,29 +886,32 @@ inline void Buffer::ClearSubData(GLenum internalformat,GLintptr offset,GLsizeipt
 		glBindBuffer(GL_PIXEL_PACK_BUFFER,ppb_binding);
 	}
 }
+#endif
 
+#ifdef GL_ALT_FUNDEF_InvalidateBufferData
 inline void Buffer::InvalidateData()
 {
 	glInvalidateBufferData(object);
 	_impl::_checkError(GL_INVALID_OPERATION,"Part of the buffer is currently mapped.");
 }
+#endif
+    
+#ifdef GL_ALT_FUNDEF_InvalidateBufferSubData
 inline void Buffer::InvalidateSubData(GLintptr offset,GLsizeiptr length)
 {
 	glInvalidateBufferSubData(object,offset,length);
 	_impl::_checkError(GL_INVALID_VALUE,"offset or length is negative, or if offset + length is greater than the value of GL_BUFFER_SIZE for buffer.");
 	_impl::_checkError(GL_INVALID_OPERATION,"Part of buffer is currently mapped.");
 }
+#endif
 
-template<class T>
-inline void Buffer::SubData(GLintptr offset,const T* b,const T* e)
-{
-	GLsizeiptr sz=(e-b);
-	SubData(offset*sizeof(T),sz*sizeof(T),reinterpret_cast<const GLvoid*>(b));
-}
 
+
+#if defined(GL_ALT_FUNDEF_MapBuffer) || defined(GL_ALT_FUNDEF_MapNamedBufferEXT)
 inline void* Buffer::Map(GLenum access)
 {
 	void *p;
+    #ifdef GL_EXT_direct_state_access
 	if(direct_state_access_supported)
 	{
 		p=glMapNamedBufferEXT(GL_PIXEL_PACK_BUFFER_BINDING,access);
@@ -864,6 +920,7 @@ inline void* Buffer::Map(GLenum access)
 		_impl::_checkError(GL_INVALID_OPERATION,"Cannot remap a buffer object whose data store is already mapped.");
 	}
 	else
+    #endif
 	{
 		GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
 		if(ppb_binding!=object)
@@ -887,17 +944,23 @@ inline typename _impl::BufferMapType<ac>::ptrtype Buffer::Map()
 {
 	return reinterpret_cast<typename _impl::BufferMapType<ac>::ptrtype>(Map(ac));
 }
+    
+#endif
 
+    
+#if defined(GL_ALT_FUNDEF_UnmapNamedBufferEXT) || defined(GL_ALT_FUNDEF_UnmapBuffer)
 inline bool Buffer::Unmap()
 {
 	bool p;
+    #ifdef GL_EXT_direct_state_access
 	if(direct_state_access_supported)
 	{
 		p=glUnmapNamedBufferEXT(object) == GL_TRUE;
 		_impl::_checkError(GL_INVALID_OPERATION,"Cannot unmap a buffer object whose data store is not mapped.");
 	}
 	else
-	{
+    #endif
+    {
 		GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
 		if(ppb_binding!=object)
 		{
@@ -913,10 +976,13 @@ inline bool Buffer::Unmap()
 	}
 	return p;
 }
+#endif
 
+#if defined(GL_ALT_FUNDEF_MapBufferRange) || defined(GL_ALT_FUNDEF_MapNamedBufferRangeEXT)
 inline void* Buffer::MapRange(GLintptr offset,GLsizeiptr length,GLbitfield access)
 {
 	void *p;
+    #ifdef GL_EXT_direct_state_access
 	if(direct_state_access_supported)
 	{
 		p=glMapNamedBufferRangeEXT(object,offset,length,access);
@@ -925,6 +991,7 @@ inline void* Buffer::MapRange(GLintptr offset,GLsizeiptr length,GLbitfield acces
 		_impl::_checkError(GL_INVALID_OPERATION,"Cannot remap a buffer object whose data store is already mapped.");
 	}
 	else
+    #endif
 	{
 		GLint ppb_binding=gl::Get<GLint>(GL_PIXEL_PACK_BUFFER_BINDING);
 		if(ppb_binding!=object)
@@ -943,17 +1010,22 @@ inline void* Buffer::MapRange(GLintptr offset,GLsizeiptr length,GLbitfield acces
 	return p;
 }
 
+
 template<GLbitfield ac>
-inline typename _impl::BufferMapType<(ac & GL_MAP_READ_BIT ? ( ac & GL_MAP_WRITE_BIT ? GL_READ_WRITE : GL_READ_ONLY) : GL_WRITE_ONLY)>::ptrtype
+    inline typename _impl::BufferMapType<ac & GL_MAP_WRITE_BIT>::ptrtype
 Buffer::MapRange(GLintptr offset,GLsizeiptr length)
 {
-	return reinterpret_cast<typename _impl::BufferMapType<(ac & GL_MAP_READ_BIT ? ( ac & GL_MAP_WRITE_BIT ? GL_READ_WRITE : GL_READ_ONLY) : GL_WRITE_ONLY)>::ptrtype>(
+	return reinterpret_cast<typename _impl::BufferMapType<ac & GL_MAP_WRITE_BIT>::ptrtype>(
 		MapRange(offset,length,ac)
 		);
 }
-
+    
+#endif
+    
+#if defined(GL_ALT_FUNDEF_NamedCopyBufferSubDataEXT) || defined(GL_ALT_FUNDEF_CopyBufferSubData)
 inline void Buffer::CopySubData(const Buffer& read,GLintptr readoffset,GLintptr writeoffset,GLsizeiptr sz)
 {
+    #ifdef GL_EXT_direct_state_access
 	if(direct_state_access_supported)
 	{
 		glNamedCopyBufferSubDataEXT(read.object,object,readoffset,writeoffset,sz);
@@ -961,6 +1033,7 @@ inline void Buffer::CopySubData(const Buffer& read,GLintptr readoffset,GLintptr 
 		_impl::_checkError(GL_INVALID_OPERATION," is generated if zero is bound to readtarget or writetarget. or the buffer object bound to either readtarget or writetarget is mapped.");
 	}
 	else
+    #endif
 	{
 		glBindBuffer(GL_COPY_READ_BUFFER,read.object);
 		_impl::_checkError(GL_INVALID_ENUM,"Cannot Bind Read Buffer: Buffer target is not one of the allowable values.");
@@ -973,6 +1046,8 @@ inline void Buffer::CopySubData(const Buffer& read,GLintptr readoffset,GLintptr 
 	}
 }
 #endif
+    
+#endif //end buffer definitions
 
 ///////////////////////////////////////////////////////////////////
 //VERTEX ARRAY DATA
@@ -990,14 +1065,16 @@ inline void VertexArray::Bind() const
 #if defined(GL_ALT_FUNDEF_EnableVertexArrayAttribEXT) || defined(GL_ALT_FUNDEF_EnableVertexAttribArray)
 inline void VertexArray::EnableAttrib(GLuint index)
 {
+    #ifdef GL_EXT_direct_state_access
 	if(direct_state_access_supported)
 	{
 		glEnableVertexArrayAttribEXT(object,index);
 		_impl::_checkError(GL_INVALID_VALUE,"Index is greater than or equal to GL_MAX_VERTEX_ATTRIBS.");
 	}
 	else
+    #endif
 	{
-		GLint pbinding=Get<GLint>(GL_VERTEX_ARRAY_BINDING);
+        GLint pbinding=Get<GLint>(GL_VERTEX_ARRAY_BINDING);
 		if(pbinding!=object)
 		{
 			glBindVertexArray(object);
@@ -1015,12 +1092,14 @@ inline void VertexArray::EnableAttrib(GLuint index)
 #if defined(GL_ALT_FUNDEF_DisableVertexArrayAttribEXT) || defined(GL_ALT_FUNDEF_DisableVertexAttribArray)
 inline void VertexArray::DisableAttrib(GLuint index)
 {
+    #ifdef GL_EXT_direct_state_access
 	if(direct_state_access_supported)
 	{
 		glDisableVertexArrayAttribEXT(object,index);
 		_impl::_checkError(GL_INVALID_VALUE,"Index is greater than or equal to GL_MAX_VERTEX_ATTRIBS.");
-	}
-	else
+    }
+    else
+    #endif
 	{
 		GLint pbinding=Get<GLint>(GL_VERTEX_ARRAY_BINDING);
 		if(pbinding!=object)
@@ -1037,11 +1116,13 @@ inline void VertexArray::DisableAttrib(GLuint index)
 }
 #endif
     
+#if defined(GL_ALT_FUNDEF_VertexArrayVertexAttribOffsetEXT) || defined(GL_ALT_FUNDEF_VertexAttribPointer)
 inline void VertexArray::AttribPointer(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const GLvoid * pointer)
 {
 	//direct state access does not seem to be supported with a 0 buffer binding.  No, it DOES..it DOES support it, its just weird.  
 	//This is like, offset blah blah blah.
 
+    #ifdef GL_EXT_direct_state_access
 	if(direct_state_access_supported)
 	{
 		glVertexArrayVertexAttribOffsetEXT(object,0,index,size,type,normalized ? GL_TRUE : GL_FALSE,stride,reinterpret_cast<GLintptr>(pointer));
@@ -1051,6 +1132,7 @@ inline void VertexArray::AttribPointer(GLuint index,GLint size,GLenum type,bool 
 	
 	}
 	else
+    #endif
 	{
 		GLint pbinding=Get<GLint>(GL_VERTEX_ARRAY_BINDING);
 		if(pbinding!=object)
@@ -1067,8 +1149,50 @@ inline void VertexArray::AttribPointer(GLuint index,GLint size,GLenum type,bool 
 		}
 	}
 }
+    
+inline void VertexArray::AttribPointer(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const Buffer& b,GLsizeiptr offset)
+{
+    #ifdef GL_EXT_direct_state_access
+    if(direct_state_access_supported)
+    {
+        glVertexArrayVertexAttribOffsetEXT(object,b.name,index,size,type,normalized ? GL_TRUE : GL_FALSE,stride,offset);
+        _impl::_checkError(GL_INVALID_VALUE,"Attribute index is greater than or equal to GL_MAX_VERTEX_ATTRIBS. OR Size is not 1, 2, 3, 4 or (for glVertexAttribPointer), GL_BGRA. OR Stride is negative.");
+        _impl::_checkError(GL_INVALID_ENUM,"Type is not an accepted value.");
+        _impl::_checkError(GL_INVALID_OPERATION,"Size is GL_BGRA and type is not GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV. OR type is GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV and size is not 4 or GL_BGRA. OR size is GL_BGRA and noramlized is GL_FALSE. OR zero is bound to the GL_ARRAY_BUFFER buffer object binding point and the pointer argument is not NULL.");
+    }
+    else
+    #endif
+    {
+        GLint bbinding=Get<GLint>(GL_ARRAY_BUFFER_BINDING);
+        if(bbinding != b.name)
+        {
+            b.Bind(GL_ARRAY_BUFFER);
+        }
+        AttribPointer(index,size,type,normalized,stride,reinterpret_cast<const void*>(offset));
+        if(bbinding != b.name)
+        {
+            glBindBuffer(GL_ARRAY_BUFFER,bbinding);
+        }
+    }
+}
+    
+inline void VertexArray::Attrib(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const GLvoid * pointer)
+{
+    AttribPointer(index,size,type,normalized,stride,pointer);
+    EnableAttrib(index);
+}
+    
+inline void VertexArray::Attrib(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const Buffer& b,GLsizeiptr offset)
+{
+    AttribPointer(index,size,type,normalized,stride,b,offset);        EnableAttrib(index);
+}
+    
+#endif
+    
+#if defined(GL_ALT_FUNDEF_VertexArrayVertexAttribIOffsetEXT) || defined(GL_ALT_FUNDEF_VertexAttribIPointer)
 inline void VertexArray::AttribIPointer(GLuint index,GLint size,GLenum type,GLsizei stride,const GLvoid * pointer)
 {
+    #ifdef GL_EXT_direct_state_access
 	if(direct_state_access_supported)
 	{
 		glVertexArrayVertexAttribIOffsetEXT(object,0,index,size,type,stride,reinterpret_cast<GLintptr>(pointer));
@@ -1077,6 +1201,7 @@ inline void VertexArray::AttribIPointer(GLuint index,GLint size,GLenum type,GLsi
 		_impl::_checkError(GL_INVALID_OPERATION,"Size is GL_BGRA and type is not GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV. OR type is GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV and size is not 4 or GL_BGRA. OR size is GL_BGRA and noramlized is GL_FALSE. OR zero is bound to the GL_ARRAY_BUFFER buffer object binding point and the pointer argument is not NULL.");
 	}
 	else
+    #endif
 	{
 		GLint pbinding=Get<GLint>(GL_VERTEX_ARRAY_BINDING);
 		if(pbinding!=object)
@@ -1094,31 +1219,10 @@ inline void VertexArray::AttribIPointer(GLuint index,GLint size,GLenum type,GLsi
 	}
 }
 
-inline void VertexArray::AttribPointer(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const Buffer& b,GLsizeiptr offset)
-{
-	if(direct_state_access_supported)
-	{
-		glVertexArrayVertexAttribOffsetEXT(object,b.name,index,size,type,normalized ? GL_TRUE : GL_FALSE,stride,offset);
-		_impl::_checkError(GL_INVALID_VALUE,"Attribute index is greater than or equal to GL_MAX_VERTEX_ATTRIBS. OR Size is not 1, 2, 3, 4 or (for glVertexAttribPointer), GL_BGRA. OR Stride is negative.");
-		_impl::_checkError(GL_INVALID_ENUM,"Type is not an accepted value.");
-		_impl::_checkError(GL_INVALID_OPERATION,"Size is GL_BGRA and type is not GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV. OR type is GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV and size is not 4 or GL_BGRA. OR size is GL_BGRA and noramlized is GL_FALSE. OR zero is bound to the GL_ARRAY_BUFFER buffer object binding point and the pointer argument is not NULL.");
-	}
-	else
-	{
-		GLint bbinding=Get<GLint>(GL_ARRAY_BUFFER_BINDING);
-		if(bbinding != b.name)
-		{
-			b.Bind(GL_ARRAY_BUFFER);
-		}
-		AttribPointer(index,size,type,normalized,stride,reinterpret_cast<const void*>(offset));
-		if(bbinding != b.name)
-		{
-			glBindBuffer(GL_ARRAY_BUFFER,bbinding);
-		}
-	}
-}
+
 inline void VertexArray::AttribIPointer(GLuint index,GLint size,GLenum type,GLsizei stride,const Buffer& b,GLsizeiptr offset)
 {
+    #ifdef GL_EXT_direct_state_access
 	if(direct_state_access_supported)
 	{
 		glVertexArrayVertexAttribIOffsetEXT(object,b.name,index,size,type,stride,offset);
@@ -1127,6 +1231,7 @@ inline void VertexArray::AttribIPointer(GLuint index,GLint size,GLenum type,GLsi
 		_impl::_checkError(GL_INVALID_OPERATION,"Size is GL_BGRA and type is not GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV. OR type is GL_INT_2_10_10_10_REV or GL_UNSIGNED_INT_2_10_10_10_REV and size is not 4 or GL_BGRA. OR size is GL_BGRA and noramlized is GL_FALSE. OR zero is bound to the GL_ARRAY_BUFFER buffer object binding point and the pointer argument is not NULL.");
 	}
 	else
+    #endif
 	{
 		GLint bbinding=Get<GLint>(GL_ARRAY_BUFFER_BINDING);
 		if(bbinding != b.name)
@@ -1140,28 +1245,19 @@ inline void VertexArray::AttribIPointer(GLuint index,GLint size,GLenum type,GLsi
 		}
 	}
 }
-
-
-inline void VertexArray::Attrib(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const GLvoid * pointer)
-{
-	AttribPointer(index,size,type,normalized,stride,pointer);
-	EnableAttrib(index);
-}
+    
 inline void VertexArray::AttribI(GLuint index,GLint size,GLenum type,GLsizei stride,const GLvoid * pointer)
 {
 	AttribIPointer(index,size,type,stride,pointer);
 	EnableAttrib(index);
 }
-inline void VertexArray::Attrib(GLuint index,GLint size,GLenum type,bool normalized,GLsizei stride,const Buffer& b,GLsizeiptr offset)
-{
-	AttribPointer(index,size,type,normalized,stride,b,offset);
-	EnableAttrib(index);
-}
+
 inline void VertexArray::AttribI(GLuint index,GLint size,GLenum type,GLsizei stride,const Buffer& b,GLsizeiptr offset)
 {
 	AttribIPointer(index,size,type,stride,b,offset);
 	EnableAttrib(index);
 }
+#endif
 
 #if defined(GL_ALT_FUNDEF_BindVertexArray) && defined(GL_ALT_FUNDEF_BindBuffer)
 inline void VertexArray::Elements(const Buffer& b)
@@ -1309,60 +1405,105 @@ inline GLuint64 Query::Get<GLuint64>(GLenum pname) const
 #endif
     
     
-
-
+ 
 inline ContextInfo::ContextInfo():
 		vendor(Get<std::string>(GL_VENDOR)),
 		renderer(Get<std::string>(GL_RENDERER)),
 		version(Get<std::string>(GL_VERSION)),
-		glsl_version(Get<std::string>(GL_SHADING_LANGUAGE_VERSION)),
-		gl_extensions(Get<GLint>(GL_NUM_EXTENSIONS)),
-		versionmajor(Get<GLint>(GL_MAJOR_VERSION)),
+		glsl_version(Get<std::string>(GL_SHADING_LANGUAGE_VERSION))
+        #if defined(GL_NUM_EXTENSIONS)
+        ,gl_extensions(Get<GLint>(GL_NUM_EXTENSIONS)),
+        #endif
+        #if defined(GL_MAJOR_VERSION) && defined(GL_MINOR_VERSION)
+        ,versionmajor(Get<GLint>(GL_MAJOR_VERSION)),
 		versionminor(Get<GLint>(GL_MINOR_VERSION))
+        #endif
 	{
+        //chris
 		for(auto vi=gl_extensions.begin();vi!=gl_extensions.end();++vi)
 		{
-			*vi=Get<std::string>(GL_EXTENSIONS,static_cast<GLsizei>(vi-gl_extensions.begin()));
+            *vi=Get<std::string>(GL_EXTENSIONS,static_cast<GLsizei>(vi-gl_extensions.begin()));
 		}
 	}
 
 
 #ifdef GL_ALT_FUNDEF_GenTextures
 
+
+    
 #if defined(GL_ALT_FUNDEF_GetIntegerv)
 inline GLint Texture::tbinding_query(GLenum target)
 {
-	static const GLenum mapping[]={
-			GL_TEXTURE_1D, GL_TEXTURE_BINDING_1D,
-			GL_TEXTURE_2D, GL_TEXTURE_BINDING_2D,
-			GL_PROXY_TEXTURE_2D, GL_TEXTURE_BINDING_2D,
-			GL_TEXTURE_1D_ARRAY, GL_TEXTURE_BINDING_1D_ARRAY,
-			GL_PROXY_TEXTURE_1D_ARRAY,GL_TEXTURE_BINDING_1D_ARRAY, 
-			GL_TEXTURE_RECTANGLE, GL_TEXTURE_BINDING_RECTANGLE,
-			GL_PROXY_TEXTURE_RECTANGLE, GL_TEXTURE_BINDING_RECTANGLE,
-			GL_TEXTURE_CUBE_MAP_POSITIVE_X,GL_TEXTURE_BINDING_CUBE_MAP, 
-			GL_TEXTURE_CUBE_MAP_NEGATIVE_X,GL_TEXTURE_BINDING_CUBE_MAP, 
-			GL_TEXTURE_CUBE_MAP_POSITIVE_Y,GL_TEXTURE_BINDING_CUBE_MAP,
-			GL_TEXTURE_CUBE_MAP_NEGATIVE_Y,GL_TEXTURE_BINDING_CUBE_MAP,
-			GL_TEXTURE_CUBE_MAP_POSITIVE_Z,GL_TEXTURE_BINDING_CUBE_MAP,
-			GL_TEXTURE_CUBE_MAP_NEGATIVE_Z,GL_TEXTURE_BINDING_CUBE_MAP,
-			GL_PROXY_TEXTURE_CUBE_MAP,GL_TEXTURE_BINDING_CUBE_MAP,
-			GL_TEXTURE_3D, GL_TEXTURE_BINDING_3D,
-			GL_PROXY_TEXTURE_3D, GL_TEXTURE_BINDING_3D,
-			GL_TEXTURE_2D_ARRAY, GL_TEXTURE_BINDING_2D_ARRAY,
-			GL_PROXY_TEXTURE_2D_ARRAY,GL_TEXTURE_BINDING_2D_ARRAY, 
-		};
-	GLenum bquery=GL_TEXTURE_BINDING_1D;
-	for(int i=0;i<sizeof(mapping)/2;i++)
-	{
-		if(target==mapping[2*i])
-		{
-			bquery=mapping[2*i+1];
-			break;
-		}
-	}
-	GLint t_binding=gl::Get<GLint>(bquery);
-	return t_binding;
+    static const GLenum mapping[]={
+    
+    #if defined(GL_TEXTURE_1D) && defined(GL_TEXTURE_BINDING_1D)
+        GL_TEXTURE_1D, GL_TEXTURE_BINDING_1D,
+    #endif
+    #if defined(GL_TEXTURE_2D) && defined(GL_TEXTURE_BINDING_2D)
+        GL_TEXTURE_2D, GL_TEXTURE_BINDING_2D,
+    #endif
+    #if defined(GL_PROXY_TEXTURE_2D) && defined(GL_TEXTURE_BINDING_2D)
+        GL_PROXY_TEXTURE_2D, GL_TEXTURE_BINDING_2D,
+    #endif
+    #if defined(GL_TEXTURE_1D_ARRAY) && defined(GL_TEXTURE_BINDING_1D_ARRAY)
+        GL_TEXTURE_1D_ARRAY, GL_TEXTURE_BINDING_1D_ARRAY,
+    #endif
+    #if defined(GL_PROXY_TEXTURE_1D_ARRAY) && defined(GL_TEXTURE_BINDING_1D_ARRAY)
+        GL_PROXY_TEXTURE_1D_ARRAY,GL_TEXTURE_BINDING_1D_ARRAY,
+    #endif
+    #if defined(GL_TEXTURE_RECTANGLE) && defined(GL_TEXTURE_BINDING_RECTANGLE)
+        GL_TEXTURE_RECTANGLE, GL_TEXTURE_BINDING_RECTANGLE,
+    #endif
+    #if defined(GL_PROXY_TEXTURE_RECTANGLE) && defined(GL_TEXTURE_BINDING_RECTANGLE)
+        GL_PROXY_TEXTURE_RECTANGLE, GL_TEXTURE_BINDING_RECTANGLE,
+    #endif
+    #if defined(GL_TEXTURE_CUBE_MAP_POSITIVE_X) && defined(GL_TEXTURE_BINDING_CUBE_MAP)
+        GL_TEXTURE_CUBE_MAP_POSITIVE_X,GL_TEXTURE_BINDING_CUBE_MAP,
+    #endif
+    #if defined(GL_TEXTURE_CUBE_MAP_NEGATIVE_X) && defined(GL_TEXTURE_BINDING_CUBE_MAP)
+        GL_TEXTURE_CUBE_MAP_NEGATIVE_X,GL_TEXTURE_BINDING_CUBE_MAP,
+    #endif
+    #if defined(GL_TEXTURE_CUBE_MAP_POSITIVE_Y) && defined(GL_TEXTURE_BINDING_CUBE_MAP)
+        GL_TEXTURE_CUBE_MAP_POSITIVE_Y,GL_TEXTURE_BINDING_CUBE_MAP,
+    #endif
+    #if defined(GL_TEXTURE_CUBE_MAP_NEGATIVE_Y) && defined(GL_TEXTURE_BINDING_CUBE_MAP)
+        GL_TEXTURE_CUBE_MAP_NEGATIVE_Y,GL_TEXTURE_BINDING_CUBE_MAP,
+    #endif
+    #if defined(GL_TEXTURE_CUBE_MAP_POSITIVE_Z) && defined(GL_TEXTURE_BINDING_CUBE_MAP)
+        GL_TEXTURE_CUBE_MAP_POSITIVE_Z,GL_TEXTURE_BINDING_CUBE_MAP,
+    #endif
+    #if defined(GL_TEXTURE_CUBE_MAP_NEGATIVE_Z) && defined(GL_TEXTURE_BINDING_CUBE_MAP)
+        GL_TEXTURE_CUBE_MAP_NEGATIVE_Z,GL_TEXTURE_BINDING_CUBE_MAP,
+    #endif
+    #if defined(GL_PROXY_TEXTURE_CUBE_MAP) && defined(GL_TEXTURE_BINDING_CUBE_MAP)
+        GL_PROXY_TEXTURE_CUBE_MAP,GL_TEXTURE_BINDING_CUBE_MAP,
+    #endif
+    #if defined(GL_TEXTURE_3D) && defined(GL_TEXTURE_BINDING_3D)
+        GL_TEXTURE_3D, GL_TEXTURE_BINDING_3D,
+    #endif
+    #if defined(GL_PROXY_TEXTURE_3D) && defined(GL_TEXTURE_BINDING_3D)
+        GL_PROXY_TEXTURE_3D, GL_TEXTURE_BINDING_3D,
+    #endif
+    #if defined(GL_TEXTURE_2D_ARRAY) && defined(GL_TEXTURE_BINDING_2D_ARRAY)
+        GL_TEXTURE_2D_ARRAY, GL_TEXTURE_BINDING_2D_ARRAY,
+    #endif
+    #if defined(GL_PROXY_TEXTURE_2D_ARRAY) && defined(GL_TEXTURE_BINDING_2D_ARRAY)
+        GL_PROXY_TEXTURE_2D_ARRAY,GL_TEXTURE_BINDING_2D_ARRAY,
+    #endif
+    };
+    
+    const std::size_t elementsInArray = sizeof(mapping) / sizeof(GLenum);
+    GLenum bquery=GL_TEXTURE_BINDING_2D;
+    for(int i=0; i< elementsInArray>>1; i++)
+    {
+        if(target==mapping[2*i])
+        {
+            bquery=mapping[2*i+1];
+            break;
+        }
+    }
+    GLint t_binding=gl::Get<GLint>(bquery);
+    return t_binding;
 }
 #endif
 
@@ -1422,12 +1563,15 @@ inline void Texture::texture_function_dsaf(Callable1 dsafunc,Callable2 ndsafunc,
 inline void Texture::BindMulti(GLuint unit,GLenum targ)
 {
 	GLenum tu = targ ? targ : m_target;
-	if (direct_state_access_supported)
+	
+    #ifdef GL_EXT_direct_state_access
+    if (direct_state_access_supported)
 	{
 		glBindMultiTextureEXT(unit, tu, object);
 	}
 	else
-	{
+    #endif
+    {
 		int at = gl::Get<int>(GL_ACTIVE_TEXTURE);
 		glActiveTexture(GL_TEXTURE0 + unit);
 		Bind(tu);
@@ -1552,7 +1696,12 @@ inline void Framebuffer::framebuffer_function_dsaf(Callable1 dsafunc,Callable2 n
 	}
 	else
 	{
-		GLenum t_binding=gl::Get<GLint>(m_target==GL_DRAW_FRAMEBUFFER ? GL_DRAW_FRAMEBUFFER_BINDING : GL_READ_FRAMEBUFFER_BINDING);
+        #if !defined(GL_DRAW_FRAMEBUFFER) || !defined(GL_READ_FRAMEBUFFER)
+            GLenum t_binding = GL_FRAMEBUFFER_BINDING;
+        #else
+            GLenum t_binding=gl::Get<GLint>(m_target==GL_DRAW_FRAMEBUFFER ? GL_DRAW_FRAMEBUFFER_BINDING : GL_READ_FRAMEBUFFER_BINDING);
+        #endif
+        
 		if(t_binding!=object)
 		{
 			glBindFramebuffer(m_target,object);
@@ -1603,7 +1752,7 @@ inline void Framebuffer::framebuffer_function_ndsaf(Callable2 ndsafunc,Types... 
 
 #ifdef	GL_ALT_FUNDEF_GenRenderbuffers
 template<class Callable1,class Callable2,typename... Types>
-inline void Renderbuffer::renderbuffer_function_dsa(Callable1 dsafunc,Callable2 ndsafunc,Types... params)
+inline void Renderbuffer::renderbuffer_function_dsaf(Callable1 dsafunc,Callable2 ndsafunc,Types... params)
 {
 	if(direct_state_access_supported)
 	{


### PR DESCRIPTION
some of this might need to be verified or cleaned up but it does build.  
caveats : still needs inline ContextInfo::ContextInfo() compatibility implementation
-gles 1.0 header seems to have build errors
-gl 1.0 header doesn’t seem to export many GL enums.
-should probably do a pass to make sure that the ifdefs in the inline
file match the header file in all cases
