### PR TITLE
Fix compile error with virtual ~Resource dtor

### DIFF
--- a/include/glhpp/Object.hpp
+++ b/include/glhpp/Object.hpp
@@ -54,7 +54,8 @@ protected:
 	{}
 	virtual ~Resource()  //This is required to be virtual in case anyone uses Object*
 	{
-		if(id!=0) 
+		//TODO: technically call Is() but we need to do a function<> dispatch to do that
+		if(id!=0/* && Is()*/) 
 		{
 			deleter_func(1,&id);
 		}


### PR DESCRIPTION
but now object validity isn't checked.  could fix by adding a check in each subclass dtor?  or a function<> dispatch